### PR TITLE
Load ASI Scripts In Mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 ASI hook that redirects file paths in Yakuza series PC games to allow loading loose files outside of game archives.
 
 # Installation
-Refer to [Ryu Mod Manager](https://github.com/SutandoTsukai181/RyuModManager), as this project is not intended to work on its own.
+Refer to [Shin Ryu Mod Manager](https://github.com/SRMM-Studio/ShinRyuModManager), as this project is not intended to work on its own.
 
 # Usage
-Please check [Ryu Mod Manager wiki](https://github.com/SutandoTsukai181/RyuModManager/wiki).
+Please check the [Shin Ryu Mod Manager wiki](https://github.com/SRMM-Studio/ShinRyuModManager/wiki).
 
 # Current Limitations
 While most of the files in the supported games can be redirected by Parless, there are some files that are loaded from other functions that are still unsupported. Future support for these files is expected. These files consist mostly of middleware audio and video containers.
@@ -14,9 +14,7 @@ The files can be summed up as the following:
 
 For Yakuza 5 only:
 ```
-ALL .usm files
 ALL .cpk files
-ALL .hca and .adx files
 ```
 
 For all games:
@@ -28,8 +26,12 @@ ALL .usm files
 Use [Premake](https://premake.github.io/) to generate the solution files.
 
 # Credits
+Original project by [SutandoTsukai181](https://github.com/SutandoTsukai181).
+
 Based on [CookiePLMonster](https://github.com/CookiePLMonster)'s SilentPatches and [ModUtils](https://github.com/CookiePLMonster/ModUtils). Also using [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader).
 
-Special thanks to Violet (SpongeX#0305) from the [Yakuza Modding Community](https://discord.gg/WQutWJq) discord for discovering a way to load unpacked PAR files, which made this project possible.
+Special thanks to [Violet](https://github.com/SamuraiOndo) for discovering a way to load unpacked PAR files, which made this project possible.
 
-Thanks to [Timo654](https://github.com/Timo654), [Capitán Retraso](https://github.com/CapitanRetraso), and metman98uk#1989 for extensive testing during the early stages of this project.
+Thanks to [Timo654](https://github.com/Timo654), [Ret](https://github.com/Ret-HZ), and [metman98uk](https://github.com/metman98uk) for extensive testing during the early stages of this project.
+
+Thanks to [Jhrino](https://github.com/Fronkln) for maintaining the project and adding new features.

--- a/premake5.lua
+++ b/premake5.lua
@@ -16,13 +16,15 @@ project "YakuzaParless"
 	files { "**/MemoryMgr.h", "**/Trampoline.h", "**/Patterns.*", "**/HookInit.hpp", "**/Maps.*" }
 
 	vpaths { ["Headers/*"] = "source/**.h",
+			["Headers/Games/*"] = { "source/Games/**.h" },
 			["Sources/*"] = { "source/**.c", "source/**.cpp" },
+			["Sources/Games*"] = { "source/Games/**.c", "source/Games/**.cpp" },
 			["Resources"] = "source/**.rc"
 	}
 
 	includedirs { "source/", "source/minhook/include" }
 
-	files { "source/*.h", "source/*.cpp", "source/resources/*.rc" }
+	files { "source/*.h", "source/*.cpp", "source/Games/*.h", "source/Games/*.cpp", "source/resources/*.rc" }
 
 	-- Disable exceptions in WIL
 	defines { "WIL_SUPPRESS_EXCEPTIONS" }

--- a/source/Games/CBaseParlessGame.cpp
+++ b/source/Games/CBaseParlessGame.cpp
@@ -1,0 +1,75 @@
+#include "CBaseParlessGame.h"
+#include "StringHelpers.h"
+
+t_parlessRename CBaseParlessGame::parless_rename_func = NULL;
+t_CriBindPath CBaseParlessGame::parless_cpk_bind_path_func = NULL;
+t_CriBind CBaseParlessGame::org_BindCpk = NULL;
+t_CriBind CBaseParlessGame::org_BindDir = NULL;
+t_CriBind(*CBaseParlessGame::hook_BindCpk) = NULL;
+
+void CBaseParlessGame::init()
+{
+	m_gameMap = get_game_map(locale);
+}
+
+std::string CBaseParlessGame::get_name()
+{
+	return std::string("Unknown");
+}
+
+bool CBaseParlessGame::can_rebuild_mlo()
+{
+	return false;
+}
+
+void CBaseParlessGame::reload()
+{
+
+}
+
+parless_stringmap CBaseParlessGame::get_game_map(Locale locale)
+{
+	return parless_stringmap();
+}
+
+std::string CBaseParlessGame::translate_path_original(std::string path, int sizeOfPath)
+{
+	std::vector<int> parts = splitPath(path, sizeOfPath, 3); //TODO!!!
+
+	string sub;
+	parless_stringmap::const_iterator match;
+
+	const int START = 1; // Start index for checking paths
+	const int MAX_SPLITS = (START + 1) + 2; // Max splits is 2
+
+	// Look for matches in the map
+	for (int i = START + 1; i < MAX_SPLITS && i < parts.size(); i++)
+	{
+		sub = path.substr(parts[START], parts[i] - parts[START]);
+		match = m_gameMap.find(sub);
+
+		if (match != m_gameMap.end())
+		{
+			// translate path
+			return path.replace(parts[START], parts[i] - parts[START], match->second);
+		}
+	}
+
+	return path;
+}
+
+std::string CBaseParlessGame::translate_path(std::string path, int sizeOfPath)
+{
+	return translate_path_original(path, sizeOfPath);
+}
+
+bool CBaseParlessGame::hook_add_file()
+{
+	return false;
+}
+
+
+bool CBaseParlessGame::hook_misc()
+{
+	return false;
+}

--- a/source/Games/CBaseParlessGame.h
+++ b/source/Games/CBaseParlessGame.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <iostream>
+
+typedef std::unordered_set<std::string> parless_stringset;
+typedef std::unordered_map<std::string, std::string> parless_stringmap;
+
+enum class Locale
+{
+	English,
+	Japanese,
+	Chinese,
+	Korean
+};
+
+typedef bool (*t_parlessRename)(char* a1);
+typedef int (*t_CriBind)(void* param_1, void* param_2, const char* path, void* param_4, int param_5, void* bindId, int param_7);
+typedef void (*t_CriBindPath)(void* param_1, void* param_2, const char* filepath, int param_7);
+
+
+class CBaseParlessGame
+{
+public:
+	Locale locale;
+
+	bool isXbox;
+	bool isUwp;
+
+	virtual std::string get_name();
+	virtual bool can_rebuild_mlo();
+	virtual parless_stringmap get_game_map(Locale locale);
+
+	virtual void init();
+
+	std::string translate_path_original(std::string path, int indexOfData);
+	virtual std::string translate_path(std::string path, int indexOfData);
+	virtual bool hook_add_file();
+	virtual bool hook_misc();
+	virtual void reload();
+
+	static bool RenameFilePaths(char* a1) { return parless_rename_func(a1); } //TEMP!!!!
+	
+	static t_CriBind(*hook_BindCpk);
+	static t_CriBind org_BindCpk;
+	static t_CriBind org_BindDir;
+
+	
+	static int BindCpk(void* param_1, void* param_2, const char* path, void* param_4, int param_5, void* bindId, int param_7)
+	{
+		std::cout << std::endl;
+		std::cout << "Binding CPK: " << path << std::endl;
+		BindCpkPaths(param_1, param_2, path, param_7);
+		return org_BindCpk(param_1, param_2, path, param_4, param_5, bindId, param_7);
+	}
+	static void BindCpkPaths(void* param_1, void* param_2, const char* filepath, int param_7) 
+	{ 
+		parless_cpk_bind_path_func(param_1, param_2, filepath, param_7); 
+	}
+
+	static t_parlessRename parless_rename_func;
+	static t_CriBindPath parless_cpk_bind_path_func;
+
+protected:
+	parless_stringmap m_gameMap;
+};

--- a/source/Games/CBaseParlessGameDE.cpp
+++ b/source/Games/CBaseParlessGameDE.cpp
@@ -1,0 +1,15 @@
+#include "CBaseParlessGameDE.h"
+#include "StringHelpers.h"
+
+std::string CBaseParlessGameDE::translate_path(std::string path, int indexOfData)
+{
+	path = translate_path_original(path, indexOfData);
+
+	if (firstIndexOf(path, "data/entity", indexOfData) != -1 && endsWith(path, ".txt"))
+	{
+		string loc = "/ja/";
+		path = rReplace(path, loc, "/");
+	}
+
+	return path;
+}

--- a/source/Games/CBaseParlessGameDE.h
+++ b/source/Games/CBaseParlessGameDE.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "CBaseParlessGame.h"
+
+class CBaseParlessGameDE : public CBaseParlessGame
+{
+public:
+	virtual std::string translate_path(std::string path, int indexOfData) override;
+};

--- a/source/Games/CBaseParlessGameOE.cpp
+++ b/source/Games/CBaseParlessGameOE.cpp
@@ -1,0 +1,28 @@
+#include "CBaseParlessGameOE.h"
+#include "StringHelpers.h"
+
+std::string CBaseParlessGameOE::translate_path_original(std::string path, int indexOfData)
+{
+	std::vector<int> parts = splitPath(path, indexOfData, 3); //TODO!!!
+
+	string sub;
+	parless_stringmap::const_iterator match;
+
+	const int START = 1; // Start index for checking paths
+	const int MAX_SPLITS = (START + 1) + 2; // Max splits is 2
+
+	// Look for matches in the map
+	for (int i = START + 1; i < MAX_SPLITS && i < parts.size(); i++)
+	{
+		sub = path.substr(parts[START], parts[i] - parts[START]);
+		match = m_gameMap.find(sub);
+
+		if (match != m_gameMap.end())
+		{
+			// translate path
+			return path.replace(parts[START], parts[i] - parts[START], match->second);
+		}
+	}
+
+	return path;
+}

--- a/source/Games/CBaseParlessGameOE.h
+++ b/source/Games/CBaseParlessGameOE.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "CBaseParlessGame.h"
+
+class CBaseParlessGameOE : public CBaseParlessGame
+{
+public:
+	std::string translate_path_original(std::string path, int indexOfData);
+};

--- a/source/Games/ParlessGameIW.cpp
+++ b/source/Games/ParlessGameIW.cpp
@@ -1,0 +1,35 @@
+#include "ParlessGameIW.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+ParlessGameIW::t_orgIWAddFileEntry ParlessGameIW::orgIWAddFileEntry = NULL;
+ParlessGameIW::t_orgIWAddFileEntry(*ParlessGameIW::hookIWAddFileEntry) = NULL;
+
+bool ParlessGameIW::hook_add_file()
+{
+	if (!isXbox)
+		hookIWAddFileEntry = (t_orgIWAddFileEntry*)pattern("48 8B C4 4C 89 48 20 89 50 10 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 68 FE FF FF").get_first(0);
+	else
+		hookIWAddFileEntry = (t_orgIWAddFileEntry*)pattern("48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 38 FE FF FF").get_first(0);
+
+	if (MH_CreateHook(hookIWAddFileEntry, &IWAddFileEntry, reinterpret_cast<LPVOID*>(&orgIWAddFileEntry)) != MH_OK)
+	{
+		cout << "Hook creation failed. Aborting.\n";
+		return false;
+	}
+
+	if (MH_EnableHook(hookIWAddFileEntry) != MH_OK)
+	{
+		cout << "Hook could not be enabled. Aborting.\n";
+		return false;
+	}
+
+	*((char*)orgIWAddFileEntry) = 0x48;
+}

--- a/source/Games/ParlessGameIW.h
+++ b/source/Games/ParlessGameIW.h
@@ -1,0 +1,42 @@
+#include "CBaseParlessGameDE.h"
+
+class ParlessGameIW : public CBaseParlessGameDE
+{
+public:
+	std::string get_name() override
+	{
+		return "Like A Dragon: Infinite Wealth";
+	}
+
+	parless_stringmap get_game_map(Locale locale) override
+	{
+		std::string curLoc;
+		std::vector<const char*> locInfWealthVec{ "de", "en", "es", "fr", "it", "ja", "ko", "zh", "zhs", "ru", "pt"};
+
+		parless_stringmap result = parless_stringmap();
+		result["/entity"] = "/entity_elvis";
+		result["/ui.elvis/texture"] = "/ui.elvis.common/texture";
+
+		for (int i = 0; i < locInfWealthVec.size(); i++)
+		{
+			curLoc = std::string(locInfWealthVec[i]);
+			result["/db.elvis/" + curLoc] = "/db.elvis." + curLoc;
+			result["/ui.elvis/" + curLoc] = "/ui.elvis." + curLoc;
+		}
+
+		return result;
+	}
+
+	bool hook_add_file() override;
+
+	typedef int (*t_orgIWAddFileEntry)(short* a1, int a2, char* a3, char** a4);
+	static t_orgIWAddFileEntry orgIWAddFileEntry;
+	static t_orgIWAddFileEntry(*hookIWAddFileEntry);
+
+	static int IWAddFileEntry(short* a1, int a2, char* a3, char** a4)
+	{
+		orgIWAddFileEntry(a1, a2, a3, a4);
+		RenameFilePaths((char*)a1);
+		return strlen((char*)a1);
+	}
+};

--- a/source/Games/ParlessGameJudge.cpp
+++ b/source/Games/ParlessGameJudge.cpp
@@ -1,0 +1,55 @@
+#include "ParlessGameJudge.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+ParlessGameJudge::t_orgLJAddFileEntry ParlessGameJudge::orgLJAddFileEntry = NULL;
+ParlessGameJudge::t_orgLJAddFileEntry(*ParlessGameJudge::hookLJAddFileEntry) = NULL;
+
+bool ParlessGameJudge::hook_add_file()
+{
+	hookLJAddFileEntry = (t_orgLJAddFileEntry*)pattern("41 57 48 8D A8 68 FE FF FF 48 81 EC 58 02 00 00 C5 F8 29 70 A8").get_first(-20);
+
+	if (MH_CreateHook(hookLJAddFileEntry, &LJAddFileEntry, reinterpret_cast<LPVOID*>(&orgLJAddFileEntry)) != MH_OK)
+	{
+		cout << "Hook creation failed. Aborting.\n";
+		return false;
+	}
+
+	if (MH_EnableHook(hookLJAddFileEntry) != MH_OK)
+	{
+		cout << "Hook could not be enabled. Aborting.\n";
+		return false;
+	}
+
+	// For some unknown reason, the pointer here is pointing to an interrupt (0xCC) that replaced the first byte of the trampoline space
+	*((char*)orgLJAddFileEntry) = 0x48;
+
+	hook_BindCpk = (t_CriBind*)get_pattern("41 57 48 8B EC 48 83 EC 70 4C 8B 6D 58", -26);
+	org_BindDir = (t_CriBind)get_pattern("41 57 48 83 EC 30 48 8B 74 24 78 33 ED", -23);
+
+	if (MH_CreateHook(hook_BindCpk, &BindCpk, reinterpret_cast<LPVOID*>(&org_BindCpk)) != MH_OK)
+	{
+		std::cout << "Hook creation failed. Aborting.\n";
+		return false;
+	}
+
+	if (MH_EnableHook(hook_BindCpk) != MH_OK)
+	{
+		std::cout << "Hook could not be enabled. Aborting.\n";
+		return false;
+	}
+
+	// Same issue as above
+	*((char*)org_BindCpk) = 0x48;
+
+	std::cout << "Applied CPK directory bind hook.\n";
+
+	return true;
+}

--- a/source/Games/ParlessGameJudge.h
+++ b/source/Games/ParlessGameJudge.h
@@ -1,0 +1,41 @@
+#include "CBaseParlessGameDE.h"
+
+class ParlessGameJudge : public CBaseParlessGameDE
+{
+public:
+	std::string get_name() override
+	{
+		return "Judgment";
+	}
+
+	parless_stringmap get_game_map(Locale locale) override
+	{
+		std::string curLoc;
+		std::vector<const char*> locJudgeVec{ "de", "en", "es", "fr", "it", "ja", "ko", "zh", "zhs" };
+
+		parless_stringmap result = parless_stringmap();
+		result["/entity"] = "/entity_judge";
+
+		for (int i = 0; i < locJudgeVec.size(); i++)
+		{
+			curLoc = std::string(locJudgeVec[i]);
+			result["/db.judge/" + curLoc] = "/db.judge." + curLoc + "/" + curLoc;
+			result["/ui.judge/" + curLoc] = "/ui.judge." + curLoc + "/" + curLoc;
+		}
+
+		return result;
+	}
+
+	bool hook_add_file() override;
+
+	typedef int (*t_orgLJAddFileEntry)(short* a1, int a2, char* a3, char** a4);
+	static t_orgLJAddFileEntry orgLJAddFileEntry;
+	static t_orgLJAddFileEntry(*hookLJAddFileEntry);
+
+	static int LJAddFileEntry(short* a1, int a2, char* a3, char** a4)
+	{
+		orgLJAddFileEntry(a1, a2, a3, a4);
+		RenameFilePaths((char*)a1);
+		return strlen((char*)a1);
+	}
+};

--- a/source/Games/ParlessGameLJ.cpp
+++ b/source/Games/ParlessGameLJ.cpp
@@ -1,0 +1,55 @@
+#include "ParlessGameLJ.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+ParlessGameLJ::t_orgLJAddFileEntry ParlessGameLJ::orgLJAddFileEntry = NULL;
+ParlessGameLJ::t_orgLJAddFileEntry(*ParlessGameLJ::hookLJAddFileEntry) = NULL;
+
+bool ParlessGameLJ::hook_add_file()
+{
+	hookLJAddFileEntry = (t_orgLJAddFileEntry*)pattern("41 57 48 8D A8 68 FE FF FF 48 81 EC 58 02 00 00 C5 F8 29 70 A8").get_first(-20);
+
+	if (MH_CreateHook(hookLJAddFileEntry, &LJAddFileEntry, reinterpret_cast<LPVOID*>(&orgLJAddFileEntry)) != MH_OK)
+	{
+		cout << "Hook creation failed. Aborting.\n";
+		return false;
+	}
+
+	if (MH_EnableHook(hookLJAddFileEntry) != MH_OK)
+	{
+		cout << "Hook could not be enabled. Aborting.\n";
+		return false;
+	}
+
+	// For some unknown reason, the pointer here is pointing to an interrupt (0xCC) that replaced the first byte of the trampoline space
+	*((char*)orgLJAddFileEntry) = 0x48;
+
+	hook_BindCpk = (t_CriBind*)get_pattern("41 57 48 8B EC 48 83 EC 70 4C 8B 6D 58", -26);
+	org_BindDir = (t_CriBind)get_pattern("41 57 48 83 EC 30 48 8B 74 24 78 33 ED", -23);
+
+	if (MH_CreateHook(hook_BindCpk, &BindCpk, reinterpret_cast<LPVOID*>(&org_BindCpk)) != MH_OK)
+	{
+		std::cout << "Hook creation failed. Aborting.\n";
+		return false;
+	}
+
+	if (MH_EnableHook(hook_BindCpk) != MH_OK)
+	{
+		std::cout << "Hook could not be enabled. Aborting.\n";
+		return false;
+	}
+
+	// Same issue as above
+	*((char*)org_BindCpk) = 0x48;
+
+	std::cout << "Applied CPK directory bind hook.\n";
+
+	return true;
+}

--- a/source/Games/ParlessGameLJ.h
+++ b/source/Games/ParlessGameLJ.h
@@ -1,0 +1,42 @@
+#include "CBaseParlessGameDE.h"
+
+class ParlessGameLJ : public CBaseParlessGameDE
+{
+public:
+	std::string get_name() override
+	{
+		return "Lost Judgment";
+	}
+
+	parless_stringmap get_game_map(Locale locale) override
+	{
+		std::string curLoc;
+		std::vector<const char*> locJudgeVec{ "de", "en", "es", "fr", "it", "ja", "ko", "zh", "zhs" };
+
+		parless_stringmap result = parless_stringmap();
+		result["/entity"] = "/entity_coyote";
+		result["/ui.coyote/texture"] = "/ui.coyote.common/texture";
+
+		for (int i = 0; i < locJudgeVec.size(); i++)
+		{
+			curLoc = std::string(locJudgeVec[i]);
+			result["/db.coyote/" + curLoc] = "/db.coyote." + curLoc;
+			result["/ui.coyote/" + curLoc] = "/ui.coyote." + curLoc;
+		}
+
+		return result;
+	}
+
+	bool hook_add_file() override;
+
+	typedef int (*t_orgLJAddFileEntry)(short* a1, int a2, char* a3, char** a4);
+	static t_orgLJAddFileEntry orgLJAddFileEntry;
+	static t_orgLJAddFileEntry(*hookLJAddFileEntry);
+
+	static int LJAddFileEntry(short* a1, int a2, char* a3, char** a4)
+	{
+		orgLJAddFileEntry(a1, a2, a3, a4);
+		RenameFilePaths((char*)a1);
+		return strlen((char*)a1);
+	}
+};

--- a/source/Games/ParlessGameOOE.cpp
+++ b/source/Games/ParlessGameOOE.cpp
@@ -1,0 +1,34 @@
+#include "ParlessGameOOE.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+__int64 (*ParlessGameOOE::orgOOEAddFileEntry)(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12) = NULL;
+__int64 (*ParlessGameOOE::orgOOEAdxEntry)(__int64 a1, __int64 a2, __int64 a3) = NULL;
+
+bool ParlessGameOOE::hook_add_file()
+{
+	void* renameFilePathsFunc;
+
+	Trampoline* trampoline = Trampoline::MakeTrampoline(GetModuleHandle(nullptr));
+
+	renameFilePathsFunc = get_pattern("66 89 83 44 02 00 00 E8 ? ? ? ? 48 8B C3 48 8B 8C 24 A0 03 00 00", -5);
+	ReadCall(renameFilePathsFunc, orgOOEAddFileEntry);
+
+	InjectHook(renameFilePathsFunc, trampoline->Jump(OOEAddFileEntry));
+
+	// Adx
+	renameFilePathsFunc = get_pattern("48 89 5C 24 18 57 48 81 EC 90 06 00 00 48 8B 05", 0x84);
+	ReadCall(renameFilePathsFunc, orgOOEAdxEntry);
+
+	InjectHook(renameFilePathsFunc, trampoline->Jump(OOEAdxEntry));
+	std::cout << "Applied ADX loading hook.\n";
+
+	return true;
+};

--- a/source/Games/ParlessGameOOE.h
+++ b/source/Games/ParlessGameOOE.h
@@ -1,0 +1,46 @@
+#include "CBaseParlessGame.h"
+
+class ParlessGameOOE : public CBaseParlessGame
+{
+public:
+	std::string get_name() override
+	{
+		return "Yakuza 3/4";
+	};
+
+	parless_stringmap get_game_map(Locale locale)
+	{
+		std::vector<const char*> loc3Vec{ "en", "ja", "zh", "ko" };
+		std::string loc3 = loc3Vec[(int)locale];
+
+		return parless_stringmap({
+				{"/font", "/fontpar/font_hd_en"}, // This is always en
+				{"/2d/cse" , "/2d/cse_" + loc3},
+				{"/2d/picture" , "/2d/picture_" + loc3},
+				{"/boot" , "/bootpar/boot_" + loc3},
+				{"/pause" , "/pausepar/pause_" + loc3},
+				{"/reactive_obj/object" , "/reactive_obj/object_hires"},
+				{"/chase" , "/chasepar/chase"},
+				{"/wdr_" + loc3 + "/common" , "/wdr_par_" + loc3 + "/common"},
+				{"/wdr_" + loc3 , "/wdr_par_" + loc3 + "/wdr"},
+			});
+	};
+
+	bool hook_add_file() override;
+
+	static __int64 (*orgOOEAddFileEntry)(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12);
+	static __int64 (*orgOOEAdxEntry)(__int64 a1, __int64 a2, __int64 a3);
+
+	static __int64 OOEAddFileEntry(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12)
+	{
+		RenameFilePaths((char*)filepath);
+		return orgOOEAddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
+	}
+
+	static __int64 OOEAdxEntry(__int64 filepath, __int64 a2, __int64 a3)
+	{
+		__int64 result = orgOOEAdxEntry(filepath, a2, a3);
+		RenameFilePaths((char*)filepath);
+		return result;
+	}
+};

--- a/source/Games/ParlessGameTMWEHI.cpp
+++ b/source/Games/ParlessGameTMWEHI.cpp
@@ -1,0 +1,35 @@
+#include "ParlessGameTMWEHI.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+ParlessGameTMWEHI::t_orgGaidenAddFileEntry ParlessGameTMWEHI::orgGaidenAddFileEntry = NULL;
+ParlessGameTMWEHI::t_orgGaidenAddFileEntry(*ParlessGameTMWEHI::hookGaidenAddFileEntry) = NULL;
+
+bool ParlessGameTMWEHI::hook_add_file()
+{
+	if (!isXbox)
+		hookGaidenAddFileEntry = (t_orgGaidenAddFileEntry*)pattern("48 8B C4 4C 89 48 20 89 50 10 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 68 FE FF FF").get_first(0);
+	else
+		hookGaidenAddFileEntry = (t_orgGaidenAddFileEntry*)pattern("48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 38 FE FF FF").get_first(0);
+
+	if (MH_CreateHook(hookGaidenAddFileEntry, &GaidenAddFileEntry, reinterpret_cast<LPVOID*>(&orgGaidenAddFileEntry)) != MH_OK)
+	{
+		cout << "Hook creation failed. Aborting.\n";
+		return false;
+	}
+
+	if (MH_EnableHook(hookGaidenAddFileEntry) != MH_OK)
+	{
+		cout << "Hook could not be enabled. Aborting.\n";
+		return false;
+	}
+
+	*((char*)orgGaidenAddFileEntry) = 0x48;
+}

--- a/source/Games/ParlessGameTMWEHI.h
+++ b/source/Games/ParlessGameTMWEHI.h
@@ -1,0 +1,42 @@
+#include "CBaseParlessGameDE.h"
+
+class ParlessGameTMWEHI : public CBaseParlessGameDE
+{
+public:
+	std::string get_name() override
+	{
+		return "Like A Dragon Gaiden: The Man Who Erased His Name";
+	}
+
+	parless_stringmap get_game_map(Locale locale) override
+	{
+		std::string curLoc;
+		std::vector<const char*> locGaidenVec{ "de", "en", "es", "fr", "it", "ja", "ko", "zh", "zhs", "ru", "pt"};
+
+		parless_stringmap result = parless_stringmap();
+		result["/entity"] = "/entity_aston";
+		result["/ui.aston/texture"] = "/ui.aston.common/texture";
+
+		for (int i = 0; i < locGaidenVec.size(); i++)
+		{
+			curLoc = std::string(locGaidenVec[i]);
+			result["/db.aston/" + curLoc] = "/db.aston." + curLoc;
+			result["/ui.aston/" + curLoc] = "/ui.aston." + curLoc;
+		}
+
+		return result;
+	}
+
+	bool hook_add_file() override;
+
+	typedef int (*t_orgGaidenAddFileEntry)(short* a1, int a2, char* a3, char** a4);
+	static t_orgGaidenAddFileEntry orgGaidenAddFileEntry;
+	static t_orgGaidenAddFileEntry(*hookGaidenAddFileEntry);
+
+	static int GaidenAddFileEntry(short* a1, int a2, char* a3, char** a4)
+	{
+		orgGaidenAddFileEntry(a1, a2, a3, a4);
+		RenameFilePaths((char*)a1);
+		return strlen((char*)a1);
+	}
+};

--- a/source/Games/ParlessGameY0.cpp
+++ b/source/Games/ParlessGameY0.cpp
@@ -1,0 +1,59 @@
+#include "ParlessGameY0.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+__int64 (*ParlessGameY0::orgY0AddFileEntry)(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13) = NULL;
+__int64 (*ParlessGameY0::orgY0CpkEntry)(__int64 a1, __int64 a2, __int64 a3, __int64 a4) = NULL;
+
+std::string ParlessGameY0::get_name()
+{
+	return "Yakuza 0";
+}
+
+bool ParlessGameY0::hook_add_file()
+{
+	void* renameFilePathsFunc;
+
+	Trampoline* trampoline = Trampoline::MakeTrampoline(GetModuleHandle(nullptr));
+
+	hook_BindCpk = (t_CriBind*)get_pattern("41 57 48 83 EC ? 4C 8B A4 24 B8 00 00 00", -22);
+	org_BindDir = (t_CriBind)0x140B35ADC;
+
+	/*
+	if (MH_CreateHook(hook_BindCpk, &CBaseParlessGame::BindCpk, reinterpret_cast<LPVOID*>(&org_BindCpk)) != MH_OK)
+	{
+		return false;
+	}
+
+	if (MH_EnableHook(hook_BindCpk) != MH_OK)
+	{
+		cout << "Hook could not be enabled. Aborting.\n";
+		return false;
+	}
+	*/
+
+	// might want to hook the other call of this function as well, but currently not necessary (?)
+	renameFilePathsFunc = get_pattern("48 89 44 24 20 48 8B D5 48 8B 0D ? ? ? ?", 15);
+	ReadCall(renameFilePathsFunc, orgY0AddFileEntry);
+
+	// this will take care of every file that is read from disk
+	InjectHook(renameFilePathsFunc, trampoline->Jump(Y0AddFileEntry));
+
+	renameFilePathsFunc = get_pattern("8B 4D D7 4A 8D 74 28 20 48 83 E6 E0 48 8D BE 9F 02 00 00", -13);
+	ReadCall(renameFilePathsFunc, orgY0CpkEntry);
+
+	InjectHook(renameFilePathsFunc, trampoline->Jump(Y0CpkEntry));
+
+	cout << "Applied CPK loading hook.\n";
+
+	org_BindCpk = (t_CriBind)((char*)org_BindCpk + 1);
+
+	return true;
+}

--- a/source/Games/ParlessGameY0.h
+++ b/source/Games/ParlessGameY0.h
@@ -1,0 +1,52 @@
+#include "CBaseParlessGameOE.h"
+
+class ParlessGameY0 : public CBaseParlessGameOE
+{
+	static __int64 (*orgY0AddFileEntry)(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13);
+	static __int64 (*orgY0CpkEntry)(__int64 a1, __int64 a2, __int64 a3, __int64 a4);
+public:
+	std::string get_name() override;
+
+	virtual parless_stringmap get_game_map(Locale locale) override
+	{
+		std::vector<const char*> loc2Vec{ "c", "j", "z", "k" };
+		std::string loc2 = loc2Vec[(int)locale];
+
+		return 	parless_stringmap({
+				{"/font" , "/fontpar/font"},
+				{"/2d/sprite_" + loc2 , "/2dpar/sprite_" + loc2},
+				{"/boot" , "/bootpar/boot"},
+				{"/stay" , "/staypar/stay"},
+				{"/sound" , "/soundpar/sound"},
+				{"/battle" , "/battlepar/battle"},
+				{"/reactor_w64" , "/reactorpar/reactor_w64"},
+				{"/wdr_" + loc2 + "/common" , "/wdr_par_" + loc2 + "/common"},
+				{"/wdr_" + loc2 , "/wdr_par_" + loc2 + "/wdr"},
+				{"/light_anim" , "/light_anim/light_anim"},
+			});
+	};
+
+	bool hook_add_file() override;
+
+
+	static __int64 Y0AddFileEntry(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13)
+	{
+		RenameFilePaths(filepath);
+		return orgY0AddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
+	}
+
+	static __int64 Y0CpkEntry(__int64 a1, __int64 filepath, __int64 a3, __int64 a4)
+	{
+		RenameFilePaths((char*)filepath);
+		return orgY0CpkEntry(a1, filepath, a3, a4);
+	}
+
+	__int64 Y0BindCPKDir(void* param_1, void* param_2, const char* path, void* param_4, int param_5, void* bindId, int param_7)
+	{
+		typedef int (*func1)();
+		func1 func_1 = (func1)0x140B31710;
+
+		if (!func_1())
+			return -1;
+	}
+};

--- a/source/Games/ParlessGameY5.cpp
+++ b/source/Games/ParlessGameY5.cpp
@@ -1,0 +1,58 @@
+#include "ParlessGameY5.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+__int64 (*ParlessGameY5::orgY5AddFileEntry)(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12, int a13, char a14);
+
+char* (*ParlessGameY5::hook_Y5AddStreamFile)(__int64 unknown, char* filePath) = NULL;
+char* (*ParlessGameY5::org_Y5AddStreamFile)(__int64 unknown, char* filePath) = NULL;
+
+bool ParlessGameY5::hook_add_file()
+{
+	void* renameFilePathsFunc;
+
+	Trampoline* trampoline = Trampoline::MakeTrampoline(GetModuleHandle(nullptr));
+
+    renameFilePathsFunc = get_pattern("48 89 4C 24 20 49 8B D7 48 8B 0D ? ? ? ?", 15);
+    ReadCall(renameFilePathsFunc, orgY5AddFileEntry);
+
+    InjectHook(renameFilePathsFunc, trampoline->Jump(Y5AddFileEntry));
+
+    hook_BindCpk = (t_CriBind*)get_pattern("41 57 48 8B EC 48 83 EC 70 4C 8B 6D 58 33 DB", -26);
+    org_BindDir = (t_CriBind)get_pattern("41 57 48 83 EC 30 48 8B 74 24 78 33 ED", -23);
+
+    if (MH_CreateHook(hook_BindCpk, &BindCpk, reinterpret_cast<LPVOID*>(&org_BindCpk)) != MH_OK)
+    {
+        cout << "Hook creation failed. Aborting.\n";
+        return false;
+    }
+
+    if (MH_EnableHook(hook_BindCpk) != MH_OK)
+    {
+        cout << "Hook could not be enabled. Aborting.\n";
+        return false;
+    }
+
+    org_BindCpk = (t_CriBind)((char*)org_BindCpk + 1);
+
+    hook_Y5AddStreamFile = (t_Y5AddStreamFile)get_pattern("40 53 48 81 EC ? ? ? ? 48 8B 05 ? ? ? ? 48 33 C4 48 89 84 24 80 06 00 00");
+
+    if (MH_CreateHook(hook_Y5AddStreamFile, &ParlessGameY5::Y5AddStreamFile, reinterpret_cast<LPVOID*>(&org_Y5AddStreamFile)) != MH_OK)
+    {
+        return false;
+    }
+
+    if (MH_EnableHook(hook_Y5AddStreamFile) != MH_OK)
+    {
+        cout << "Hook could not be enabled. Aborting.\n";
+        return false;
+    }
+
+}

--- a/source/Games/ParlessGameY5.h
+++ b/source/Games/ParlessGameY5.h
@@ -1,0 +1,53 @@
+#include "CBaseParlessGameOE.h"
+
+class ParlessGameY5 : public CBaseParlessGameOE
+{
+public:
+	std::string get_name() override
+	{
+		return "Yakuza 5";
+	}
+
+	parless_stringmap get_game_map(Locale locale) override
+	{
+		std::vector<const char*> loc3Vec{ "en", "ja", "zh", "ko" };
+		std::string loc3 = loc3Vec[(int)locale];
+
+		return parless_stringmap({
+				{"/font", "/fontpar/font_hd_en"}, // This is always en
+				{"/font_qloc", "/fontpar/font_q_icons"},
+				{"/2d/sprite" , "/2dpar/sprite_" + loc3},
+				{"/2d/ui" , "/2dpar/ui_" + loc3},
+				{"/boot" , "/bootpar/boot_" + loc3},
+				{"/stay" , "/staypar/stay_" + loc3},
+				{"/pause" , "/pausepar/pause_" + loc3},
+				{"/reactor" , "/reactorpar/reactor"},
+				{"/sound" , "/soundpar/sound"},
+				{"/battle" , "/battlepar/battle"},
+				{"/wdr_" + loc3 + "/common" , "/wdr_par_" + loc3 + "/common"},
+				{"/wdr_" + loc3 , "/wdr_par_" + loc3 + "/wdr"},
+			});
+	};
+
+	bool hook_add_file() override;
+
+
+public:
+	static __int64 (*orgY5AddFileEntry)(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12, int a13, char a14);
+	typedef char* (*t_Y5AddStreamFile)(__int64 unknown, char* filePath);
+
+	static t_Y5AddStreamFile hook_Y5AddStreamFile;
+	static t_Y5AddStreamFile org_Y5AddStreamFile;
+
+	static __int64 Y5AddFileEntry(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12, int a13, char a14)
+	{
+		RenameFilePaths((char*)filepath);
+		return orgY5AddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
+	}
+
+	static void Y5AddStreamFile(__int64 unknown, char* filePath)
+	{
+		RenameFilePaths(filePath);
+		org_Y5AddStreamFile(unknown, filePath);
+	}
+};

--- a/source/Games/ParlessGameY6.cpp
+++ b/source/Games/ParlessGameY6.cpp
@@ -1,0 +1,126 @@
+#include "ParlessGameY6.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+int (*ParlessGameY6::orgY6AddFileEntry)(int* param_1, int* param_2, char* param_3) = NULL;
+uint64_t(*ParlessGameY6::orgY6SprintfAwb)(uint64_t param_1, uint64_t param_2, uint64_t param_3, uint64_t param_4) = NULL;
+
+std::string ParlessGameY6::translate_path(std::string path, int indexOfData)
+{
+	path = translate_path_original(path, indexOfData);
+
+	if (firstIndexOf(path, "data/entity", indexOfData) != -1 && endsWith(path, ".txt"))
+	{
+		string loc = "/ja/";
+
+		if (locale == Locale::English)
+			loc = "/e/";
+
+		path = rReplace(path, loc, "/");
+	}
+
+	return path;
+};
+
+bool ParlessGameY6::hook_add_file()
+{
+	void* renameFilePathsFunc;
+	uint8_t STR_LEN_ADD = 0x40;
+
+	// Hook inside the method that calculates a string's length to add 0x20 bytes to the length
+	// This is needed to prevent undefined behavior when the modified path is longer than the memory allocated to it
+	
+	
+	auto stringLenAddrPat = pattern("8B CD 3B D9 77 47");
+	void* stringLenAddr = 0;
+	bool isGOG = GetModuleHandle(L"galaxy64") != nullptr;
+
+	//GOG
+	if (!isGOG)
+		stringLenAddr = get_pattern("8B CD 3B D9 77 47", -0x1C);
+
+	Trampoline* trampoline = Trampoline::MakeTrampoline(GetModuleHandle(nullptr));
+	Trampoline* trampolineStringLen = Trampoline::MakeTrampoline(stringLenAddr);
+
+	const uint8_t spacePayload[] = {
+		0x48, 0x03, 0xD8, // add rbx, rax
+		0x2B, 0xDE, // sub ebx, esi
+		0x48, 0x83, 0xC3, STR_LEN_ADD, // add rbx, 0x20
+		0x48, 0x8B, 0x07, // mov rax, qword ptr ds:[rdi]
+		0xE9, 0x0, 0x0, 0x0, 0x0 // jmp stringLenAddr+8
+	};
+
+	std::byte* space = trampolineStringLen->RawSpace(sizeof(spacePayload));
+	memcpy(space, spacePayload, sizeof(spacePayload));
+
+
+	//Path extension not needed in GOG
+	if (!isGOG)
+	{
+		WriteOffsetValue(space + 3 + 2 + 4 + 3 + 1, reinterpret_cast<intptr_t>(stringLenAddr) + 8);
+
+		const uint8_t funcPayload[] = {
+			0x48, 0x8B, 0xDB, // mov rbx, rbx
+			0xE9, 0x0, 0x0, 0x0, 0x0 // jmp space
+		};
+
+		memcpy(stringLenAddr, funcPayload, sizeof(funcPayload));
+
+		InjectHook(reinterpret_cast<intptr_t>(stringLenAddr) + 3, space, PATCH_JUMP);
+		std::cout << "Applied file path extension hook.\n";
+	}
+
+	// Hook the AddFileEntry method to get each filepath that is loaded in the game
+
+	// This function we're hooking is called from multiple places and the result we want to
+	// change will not be available after the function returns.
+	// So instead, hook the first couple of instructions of the function
+	renameFilePathsFunc = get_pattern("48 8D 8D 00 04 00 00 48 89 85 00 04 00 00", -0x62);
+	Trampoline* trampolineDE = Trampoline::MakeTrampoline(renameFilePathsFunc);
+
+	const uint8_t spacePayload2[] = {
+		0xE9, 0x0, 0x0, 0x0, 0x0, // jmp Y6AddFileEntry
+		0x48, 0x89, 0x4C, 0x24, 0x08, // mov qword ptr ss : [rsp + 8] , rcx
+		0x55, // push rbp
+		0x53, // push rbx
+		0x41, 0x55, // push r13
+		0xE9, 0x0, 0x0, 0x0, 0x0 // jmp renameFilePathsFunc+9
+	};
+
+	std::byte* space2 = trampolineDE->RawSpace(sizeof(spacePayload2));
+	memcpy(space2, spacePayload2, sizeof(spacePayload2));
+
+	intptr_t srcAddr = (intptr_t)(space2 + 5);
+	orgY6AddFileEntry = {};
+	memcpy(std::addressof(orgY6AddFileEntry), &srcAddr, sizeof(srcAddr));
+
+	InjectHook(space2, trampoline->Jump(Y6AddFileEntry));
+	WriteOffsetValue(space2 + 5 + 5 + 1 + 1 + 2 + 1, reinterpret_cast<intptr_t>(renameFilePathsFunc) + 9);
+
+	// First byte of the function is not writable for some reason, so instead we make the instruction do nothing
+	const uint8_t funcPayload2[] = {
+		0x48, 0x89, 0xC9, // mov rcx, rcx
+		0xE9, 0x0, 0x0, 0x0, 0x0, // jmp space2
+		0x90 // nop
+	};
+
+	memcpy(renameFilePathsFunc, funcPayload2, sizeof(funcPayload2));
+
+	InjectHook(reinterpret_cast<intptr_t>(renameFilePathsFunc) + 3, space2, PATCH_JUMP);
+
+	// AWB files are not passed over to the normal file entry function
+	auto sprintfAWBs = get_pattern("E8 ? ? ? ? 4C 8D 4C 24 60 45 33 C0");
+	ReadCall(sprintfAWBs, orgY6SprintfAwb);
+
+	InjectHook(sprintfAWBs, trampoline->Jump(Y6SprintfAwb));
+	cout << "Applied AWB loading hook.\n";
+
+	return true;
+};

--- a/source/Games/ParlessGameY6.h
+++ b/source/Games/ParlessGameY6.h
@@ -1,0 +1,33 @@
+#include "CBaseParlessGameDE.h"
+
+class ParlessGameY6 : public CBaseParlessGameDE
+{
+	static int (*orgY6AddFileEntry)(int* param_1, int* param_2, char* param_3);
+	static uint64_t(*orgY6SprintfAwb)(uint64_t param_1, uint64_t param_2, uint64_t param_3, uint64_t param_4);
+
+	virtual std::string get_name() override
+	{
+		return "Yakuza 6: The Song Of Life";
+	};
+
+	virtual parless_stringmap get_game_map(Locale locale) override
+	{
+		return parless_stringmap();
+	};
+
+	virtual std::string translate_path(std::string path, int indexOfData) override;
+	virtual bool hook_add_file() override;
+
+	static int Y6AddFileEntry(int* a1, int* a2, char* filepath)
+	{
+		RenameFilePaths(filepath);
+		return orgY6AddFileEntry(a1, a2, filepath);
+	}
+
+	static uint64_t Y6SprintfAwb(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4)
+	{
+		uint64_t result = orgY6SprintfAwb(a1, a2, a3, a4);
+		RenameFilePaths((char*)result);
+		return result;
+	}
+};

--- a/source/Games/ParlessGameYK1.cpp
+++ b/source/Games/ParlessGameYK1.cpp
@@ -1,0 +1,59 @@
+#include "ParlessGameYK1.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+__int64 (*ParlessGameYK1::orgYK1AddFileEntry)(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13) = NULL;
+__int64 (*ParlessGameYK1::orgYK1CpkEntry)(__int64 a1, __int64 a2, __int64 a3, __int64 a4) = NULL;
+
+std::string ParlessGameYK1::get_name()
+{
+	return "Yakuza Kiwami";
+}
+
+bool ParlessGameYK1::hook_add_file()
+{
+	void* renameFilePathsFunc;
+
+	Trampoline* trampoline = Trampoline::MakeTrampoline(GetModuleHandle(nullptr));
+
+	hook_BindCpk = (t_CriBind*)get_pattern("41 57 48 8B EC 48 83 EC 70 4C 8B 6D 58", -26);
+	org_BindDir = (t_CriBind)get_pattern("41 57 48 8B EC 48 83 EC ? 4C 8B 6D 58", -26);
+
+	/*
+	if (MH_CreateHook(hook_BindCpk, &CBaseParlessGame::BindCpk, reinterpret_cast<LPVOID*>(&org_BindCpk)) != MH_OK)
+	{
+		return false;
+	}
+
+	if (MH_EnableHook(hook_BindCpk) != MH_OK)
+	{
+		cout << "Hook could not be enabled. Aborting.\n";
+		return false;
+	}
+	*/
+
+	// might want to hook the other call of this function as well, but currently not necessary (?)
+	renameFilePathsFunc = get_pattern("48 89 44 24 20 48 8B D5 48 8B 0D ? ? ? ?", 15);
+	ReadCall(renameFilePathsFunc, orgYK1AddFileEntry);
+
+	// this will take care of every file that is read from disk
+	InjectHook(renameFilePathsFunc, trampoline->Jump(YK1AddFileEntry));
+
+	renameFilePathsFunc = get_pattern("8B 4D DF 48 8D 70 20 49 03 F6 48 83 E6 E0", -13);
+	ReadCall(renameFilePathsFunc, orgYK1CpkEntry);
+
+	InjectHook(renameFilePathsFunc, trampoline->Jump(YK1CpkEntry));
+
+	cout << "Applied CPK loading hook.\n";
+
+	org_BindCpk = (t_CriBind)((char*)org_BindCpk + 1);
+
+	return true;
+}

--- a/source/Games/ParlessGameYK1.h
+++ b/source/Games/ParlessGameYK1.h
@@ -1,0 +1,43 @@
+#include "CBaseParlessGameOE.h"
+
+class ParlessGameYK1 : public CBaseParlessGameOE
+{
+	static __int64 (*orgYK1AddFileEntry)(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13);
+	static __int64 (*orgYK1CpkEntry)(__int64 a1, __int64 a2, __int64 a3, __int64 a4);
+public:
+	std::string get_name() override;
+
+	bool hook_add_file() override;
+
+	virtual parless_stringmap get_game_map(Locale locale) override
+	{
+		std::vector<const char*> loc2Vec{ "c", "j", "z", "k" };
+		std::string loc2 = loc2Vec[(int)locale];
+
+		return 	parless_stringmap({
+				{"/font" , "/fontpar/font"},
+				{"/2d/sprite_" + loc2 , "/2dpar/sprite_" + loc2},
+				{"/boot" , "/bootpar/boot"},
+				{"/stay" , "/staypar/stay"},
+				{"/sound" , "/soundpar/sound"},
+				{"/battle" , "/battlepar/battle"},
+				{"/reactor_w64" , "/reactorpar/reactor_w64"},
+				{"/wdr_" + loc2 + "/common" , "/wdr_par_" + loc2 + "/common"},
+				{"/wdr_" + loc2 , "/wdr_par_" + loc2 + "/wdr"},
+				{"/light_anim" , "/light_anim/light_anim"},
+			});
+	};
+
+
+	static __int64 YK1AddFileEntry(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13)
+	{
+		RenameFilePaths(filepath);
+		return orgYK1AddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
+	}
+
+	static __int64 YK1CpkEntry(__int64 a1, __int64 filepath, __int64 a3, __int64 a4)
+	{
+		RenameFilePaths((char*)filepath);
+		return orgYK1CpkEntry(a1, filepath, a3, a4);
+	}
+};

--- a/source/Games/ParlessGameYK2.cpp
+++ b/source/Games/ParlessGameYK2.cpp
@@ -1,0 +1,84 @@
+#include "ParlessGameYK2.h"
+#include "StringHelpers.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+#include <iostream>
+
+using namespace hook;
+using namespace Memory;
+
+int (*ParlessGameYK2::orgYK2AddFileEntry)(int* param_1, int* param_2, char* param_3) = NULL;
+uint64_t(*ParlessGameYK2::orgYK2SprintfAwb)(uint64_t param_1, uint64_t param_2, uint64_t param_3, uint64_t param_4) = NULL;
+
+std::string ParlessGameYK2::translate_path(std::string path, int indexOfData)
+{
+	path = translate_path_original(path, indexOfData);
+
+	if (firstIndexOf(path, "data/entity", indexOfData) != -1 && endsWith(path, ".txt"))
+	{
+		string loc = "/ja/";
+
+		if (locale == Locale::English)
+			loc = "/en/";
+
+		path = rReplace(path, loc, "/");
+	}
+
+	return path;
+}
+
+bool ParlessGameYK2::hook_add_file()
+{
+	void* renameFilePathsFunc;
+	uint8_t STR_LEN_ADD = 0x40;
+
+	// Hook inside the method that calculates a string's length to add 0x20 bytes to the length
+// This is needed to prevent undefined behavior when the modified path is longer than the memory allocated to it
+	auto stringLenAddr = get_pattern("8B C7 3B D8 77 4E", -0x1C);
+
+	Trampoline* trampoline = Trampoline::MakeTrampoline(GetModuleHandle(nullptr));
+	Trampoline* trampolineStringLen = Trampoline::MakeTrampoline(stringLenAddr);
+
+	const uint8_t spacePayload[] = {
+		0x48, 0x8B, 0x09, // mov rcx, qword ptr ds:[rcx]
+		0x48, 0x83, 0xC3, STR_LEN_ADD, // add rbx, 0x20
+		0x48, 0x8B, 0xC1, // mov rax, rcx
+		0x48, 0xC1, 0xE8, 0x2C, // shr rax, 0x2C
+		0xE9, 0x0, 0x0, 0x0, 0x0 // jmp stringLenAddr+0xA
+	};
+
+	std::byte* space = trampolineStringLen->RawSpace(sizeof(spacePayload));
+	memcpy(space, spacePayload, sizeof(spacePayload));
+
+	WriteOffsetValue(space + 3 + 4 + 3 + 4 + 1, reinterpret_cast<intptr_t>(stringLenAddr) + 0xA);
+
+	const uint8_t funcPayload[] = {
+		0x48, 0x8B, 0xDB, // mov rbx, rbx
+		0x90, 0x90, // nop
+		0xE9, 0x0, 0x0, 0x0, 0x0 // jmp space2
+	};
+
+	memcpy(stringLenAddr, funcPayload, sizeof(funcPayload));
+
+	InjectHook(reinterpret_cast<intptr_t>(stringLenAddr) + 5, space, PATCH_JUMP);
+	std::cout << "Applied file path extension hook.\n";
+
+	// Hook the AddFileEntry method to get each filepath that is loaded in the game
+
+	// Unlike Y6, K2 has a good place to hook the call instead of hooking the first instruction of the function
+	renameFilePathsFunc = get_pattern("4C 8D 44 24 20 48 8B D3 48 8B CF", -5);
+	ReadCall(renameFilePathsFunc, orgYK2AddFileEntry);
+
+	InjectHook(renameFilePathsFunc, trampoline->Jump(YK2AddFileEntry));
+
+	// AWB files are not passed over to the normal file entry function
+	auto sprintfAWBs = get_pattern("4C 8D 4C 24 70 45 33 C0 41 8B D5 49 8B CC", -5);
+	ReadCall(sprintfAWBs, orgYK2SprintfAwb);
+
+	InjectHook(sprintfAWBs, trampoline->Jump(YK2SprintfAwb));
+	std::cout << "Applied AWB loading hook.\n";
+
+	return true;
+}

--- a/source/Games/ParlessGameYK2.h
+++ b/source/Games/ParlessGameYK2.h
@@ -1,0 +1,33 @@
+#include "CBaseParlessGameDE.h"
+
+class ParlessGameYK2 : public CBaseParlessGameDE
+{
+	static int (*orgYK2AddFileEntry)(int* param_1, int* param_2, char* param_3);
+	static uint64_t(*orgYK2SprintfAwb)(uint64_t param_1, uint64_t param_2, uint64_t param_3, uint64_t param_4);
+
+	virtual std::string get_name() override
+	{
+		return "Yakuza Kiwami 2";
+	};
+	
+	virtual parless_stringmap get_game_map(Locale locale) override
+	{
+		return parless_stringmap();
+	};
+
+	virtual std::string translate_path(std::string path, int indexOfData) override;
+	virtual bool hook_add_file() override;
+
+	static int YK2AddFileEntry(int* a1, int* a2, char* filepath)
+	{
+		RenameFilePaths(filepath);
+		return orgYK2AddFileEntry(a1, a2, filepath);
+	}
+
+	static uint64_t YK2SprintfAwb(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4)
+	{
+		uint64_t result = orgYK2SprintfAwb(a1, a2, a3, a4);
+		RenameFilePaths((char*)result);
+		return result;
+	}
+};

--- a/source/Games/ParlessGameYLAD.cpp
+++ b/source/Games/ParlessGameYLAD.cpp
@@ -1,0 +1,69 @@
+#include "ParlessGameYLAD.h"
+#include "Utils/MemoryMgr.h"
+#include "Utils/Trampoline.h"
+#include "Utils/Patterns.h"
+#include <MinHook.h>
+
+using namespace hook;
+using namespace Memory;
+
+ParlessGameYLAD::t_orgYLaDAddFileEntry ParlessGameYLAD::orgYLaDAddFileEntry = NULL;
+ParlessGameYLAD::t_orgYLaDAddFileEntry* ParlessGameYLAD::hookYLaDAddFileEntry = NULL;
+
+ParlessGameYLAD::t_orgYLaDFilepath ParlessGameYLAD::orgYLaDFilepath = NULL;
+ParlessGameYLAD::t_orgYLaDFilepath* ParlessGameYLAD::hookYLaDFilepath = NULL;
+
+bool ParlessGameYLAD::hook_add_file()
+{
+	void* renameFilePathsFunc;
+
+	// Y7 need hooks for two different functions
+
+// File loading hook
+	if (isUwp)
+	{
+		renameFilePathsFunc = get_pattern("48 83 EC 28 4C 8B C2 4C 8D 4C 24 40 BA 10 04 00 00 E8", 17);
+	}
+	else
+	{
+		auto pat = pattern("48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 48 83 EC 28 4C 8B C2 4C 8D 4C 24 40 BA 10 04 00 00 E8");
+
+		// Try the UWP pattern if the main pattern doesn't match
+		if (pat.size() < 5)
+		{
+			renameFilePathsFunc = get_pattern("48 83 EC 28 4C 8B C2 4C 8D 4C 24 40 BA 10 04 00 00 E8", 17);
+		}
+		else
+		{
+			renameFilePathsFunc = pat.get(4).get<void>(32);
+		}
+	}
+
+	ReadCall(renameFilePathsFunc, hookYLaDAddFileEntry);
+
+	if (MH_CreateHook(hookYLaDAddFileEntry, &ParlessGameYLAD::YLaDAddFileEntry, reinterpret_cast<LPVOID*>(&orgYLaDAddFileEntry)) != MH_OK)
+		return false;
+
+	if (MH_EnableHook(hookYLaDAddFileEntry) != MH_OK)
+		return false;
+
+	// Filepath hook
+	if (isUwp)
+	{
+		renameFilePathsFunc = get_pattern("44 8D 4F 03 BA 10 04 00 00 4C 8D 84 24 50 06 00 00 48 8D 8C 24 60 0A 00 00 E8", 25);
+	}
+	else
+	{
+		renameFilePathsFunc = get_pattern("44 8D 4D 03 4C 8D 84 24 40 02 00 00 BA 10 04 00 00 48 8D 8C 24 B0 0C 00 00 E8", 25);
+	}
+
+	ReadCall(renameFilePathsFunc, hookYLaDFilepath);
+
+	if (MH_CreateHook(hookYLaDFilepath, &YLaDFilepath, reinterpret_cast<LPVOID*>(&orgYLaDFilepath)) != MH_OK)
+		return false;
+
+	if (MH_EnableHook(hookYLaDFilepath) != MH_OK)
+		return false;
+
+	return true;
+}

--- a/source/Games/ParlessGameYLAD.h
+++ b/source/Games/ParlessGameYLAD.h
@@ -1,0 +1,52 @@
+#include "CBaseParlessGameDE.h"
+#include <iostream>
+
+class ParlessGameYLAD : public CBaseParlessGameDE
+{
+	virtual std::string get_name() override
+	{
+		return "Yakuza: Like a Dragon";
+	};
+
+	virtual parless_stringmap get_game_map(Locale locale) override
+	{
+		std::string curLoc;
+		std::vector<const char*> locY7Vec{ "de", "en", "es", "fr", "it", "ja", "ko", "pt", "ru", "zh", "zhs", "pt"};
+
+		parless_stringmap result = parless_stringmap();
+		result["/entity"] = "/entity_yazawa";
+
+		for (int i = 0; i < locY7Vec.size(); i++)
+		{
+			curLoc = std::string(locY7Vec[i]);
+			result["/db.yazawa/" + curLoc] = "/db.yazawa." + curLoc + "/" + curLoc;
+			result["/ui.yazawa/" + curLoc] = "/ui.yazawa." + curLoc + "/" + curLoc;
+		}
+
+		return result;
+	}
+
+	virtual bool hook_add_file() override;
+
+private:
+	typedef char* (*t_orgYLaDAddFileEntry)(char* a1, uint64_t a2, char* a3, char* a4);
+	static t_orgYLaDAddFileEntry orgYLaDAddFileEntry;
+	static t_orgYLaDAddFileEntry(*hookYLaDAddFileEntry);
+
+	typedef void (*t_orgYLaDFilepath)(char* a1, uint64_t a2, char* a3, uint64_t a4);
+	static t_orgYLaDFilepath orgYLaDFilepath;
+	static t_orgYLaDFilepath(*hookYLaDFilepath);
+
+	static char* YLaDAddFileEntry(char* a1, uint64_t a2, char* a3, char* a4)
+	{
+		char* result = orgYLaDAddFileEntry(a1, a2, a3, a4);
+		RenameFilePaths(a1);
+		return result;
+	}
+
+	static void YLaDFilepath(char* a1, uint64_t a2, char* a3, uint64_t a4)
+	{
+		RenameFilePaths(a3);
+		orgYLaDFilepath(a1, a2, a3, a4);
+	}
+};

--- a/source/Maps.h
+++ b/source/Maps.h
@@ -45,6 +45,7 @@ Game getGame(string name)
 	if (name == "Judgment") return Game::Judgment;
 	if (name == "LostJudgment") return Game::LostJudgment;
 	if (name == "LikeaDragonGaiden") return Game::LikeADragonGaidenTheManWhoErasedHisName;
+	if (name == "LikeADragonGaiden") return Game::LikeADragonGaidenTheManWhoErasedHisName;
 	if (name == "LikeADragon8") return Game::LikeADragonInfiniteWealth;
 
 	return Game::Unsupported;

--- a/source/Maps.h
+++ b/source/Maps.h
@@ -33,13 +33,14 @@ enum class Game
 
 Game getGame(string name)
 {
-	if (name == "Yakuza3") return Game::Yakuza3;
-	if (name == "Yakuza4") return Game::Yakuza4;
-	if (name == "Yakuza5") return Game::Yakuza5;
-	if (name == "Yakuza0") return Game::Yakuza0;
-	if (name == "YakuzaKiwami") return Game::YakuzaKiwami;
-	if (name == "Yakuza6") return Game::Yakuza6;
-	if (name == "YakuzaKiwami2") return Game::YakuzaKiwami2;
+
+	if (startsWith(name, "Yakuza3")) return Game::Yakuza3;
+	if (startsWith(name, "Yakuza4")) return Game::Yakuza4;
+	if (startsWith(name, "Yakuza5")) return Game::Yakuza5;
+	if (startsWith(name, "Yakuza0")) return Game::Yakuza0;
+	if (startsWith(name, "YakuzaKiwami")) return Game::YakuzaKiwami;
+	if (startsWith(name, "Yakuza6")) return Game::Yakuza6;
+	if (startsWith(name, "YakuzaKiwami2")) return Game::YakuzaKiwami2;
 	if (name == "YakuzaLikeADragon") return Game::YakuzaLikeADragon;
 	if (name == "eve") return Game::VFeSports;
 	if (name == "Judgment") return Game::Judgment;
@@ -89,62 +90,6 @@ const char* getGameName(Game game)
 	}
 }
 
-enum class Locale
-{
-	English,
-	Japanese,
-	Chinese,
-	Korean
-};
-
-/// <summary>
-/// Translates a path using a map
-/// </summary>
-/// <param name="pathMap"></param>
-/// <param name="path"></param>
-/// <param name="parts"></param>
-/// <returns></returns>
-string translatePath(stringmap pathMap, string path, vector<int> parts)
-{
-	string sub;
-	stringmap::const_iterator match;
-
-	const int START = 1; // Start index for checking paths
-	const int MAX_SPLITS = (START + 1) + 2; // Max splits is 2
-
-	// Look for matches in the map
-	for (int i = START + 1; i < MAX_SPLITS && i < parts.size(); i++)
-	{
-		sub = path.substr(parts[START], parts[i] - parts[START]);
-		match = pathMap.find(sub);
-
-		if (match != pathMap.end())
-		{
-			// translate path
-			return path.replace(parts[START], parts[i] - parts[START], match->second);
-		}
-	}
-
-	return path;
-}
-
-string translatePathDE(string path, int indexOfData, Game game, Locale locale)
-{
-	if (firstIndexOf(path, "data/entity", indexOfData) != -1 && endsWith(path, ".txt"))
-	{
-		string loc = "/ja/";
-		if (locale == Locale::English)
-		{
-			if (game == Game::YakuzaKiwami2) loc = "/en/";
-			else if (game == Game::Yakuza6) loc = "/e/";
-		}
-
-		path = rReplace(path, loc, "/");
-	}
-
-	return path;
-}
-
 string removeParlessPath(string path, int indexOfData)
 {
 	size_t pos = firstIndexOf(path, ".parless", indexOfData);
@@ -168,7 +113,7 @@ string removeModPath(string path, int indexOfData)
 
 	return path;
 }
-
+/*
 stringmap getGameMap(Game game, Locale locale)
 {
 	vector<const char*> loc1Vec{ "e", "j", "z", "k" };
@@ -363,3 +308,4 @@ stringmap getGameMap(Game game, Locale locale)
 			return stringmap();
 	}
 }
+*/

--- a/source/Maps.h
+++ b/source/Maps.h
@@ -26,6 +26,9 @@ enum class Game
 	Judgment,
 	LostJudgment,
 	VFeSports,
+	LikeADragonGaidenTheManWhoErasedHisName,
+	LikeADragonInfiniteWealthDemo,
+	LikeADragonInfiniteWealth
 };
 
 Game getGame(string name)
@@ -41,6 +44,8 @@ Game getGame(string name)
 	if (name == "eve") return Game::VFeSports;
 	if (name == "Judgment") return Game::Judgment;
 	if (name == "LostJudgment") return Game::LostJudgment;
+	if (name == "LikeaDragonGaiden") return Game::LikeADragonGaidenTheManWhoErasedHisName;
+	if (name == "LikeADragon8") return Game::LikeADragonInfiniteWealth;
 
 	return Game::Unsupported;
 }
@@ -71,6 +76,12 @@ const char* getGameName(Game game)
 			return "Lost Judgment";
 		case Game::VFeSports:
 			return "Virtua Fighter eSports";
+		case Game::LikeADragonGaidenTheManWhoErasedHisName:
+			return "Like a Dragon Gaiden: The Man Who Erased His Name";
+		case Game::LikeADragonInfiniteWealthDemo:
+			return "Like a Dragon: Infinite Wealth";
+		case Game::LikeADragonInfiniteWealth:
+			return "Like a Dragon: Infinite Wealth";
 		case Game::Unsupported:
 		default:
 			return "Unsupported";
@@ -280,6 +291,62 @@ stringmap getGameMap(Game game, Locale locale)
 				curLoc = string(locJudgeVec[i]);
 				result["/db.coyote/" + curLoc] = "/db.coyote." + curLoc;
 				result["/ui.coyote/" + curLoc] = "/ui.coyote." + curLoc;
+			}
+
+			return result;
+		}
+		case Game::LikeADragonGaidenTheManWhoErasedHisName:
+		{
+			string curLoc;
+			vector<const char*> locGaidenVec{ "de", "en", "es", "fr", "it", "ja", "ko", "zh", "zhs", "ru"};
+
+			result = stringmap();
+			result["/entity"] = "/entity_aston";
+			result["/ui.aston/texture"] = "/ui.aston.common/texture";
+
+			for (int i = 0; i < locGaidenVec.size(); i++)
+			{
+				curLoc = string(locGaidenVec[i]);
+				result["/db.aston/" + curLoc] = "/db.aston." + curLoc;
+				result["/ui.aston/" + curLoc] = "/ui.aston." + curLoc;
+			}
+
+			return result;
+		}
+
+		case Game::LikeADragonInfiniteWealthDemo:
+		{
+			string curLoc;
+			vector<const char*> locInfWealthVec{ "de", "en", "es", "fr", "it", "ja", "ko", "zh", "zhs", "ru" };
+
+			result = stringmap();
+			result["/entity"] = "/entity_elvis";
+			result["/ui.elvis/texture"] = "/ui.elvis.common/texture";
+
+			for (int i = 0; i < locInfWealthVec.size(); i++)
+			{
+				curLoc = string(locInfWealthVec[i]);
+				result["/db.elvis.trial/" + curLoc] = "/db.elvis.trial" + curLoc;
+				result["/ui.elvis/" + curLoc] = "/ui.elvis." + curLoc;
+			}
+
+			return result;
+		}
+
+		case Game::LikeADragonInfiniteWealth:
+		{
+			string curLoc;
+			vector<const char*> locInfWealthVec{ "de", "en", "es", "fr", "it", "ja", "ko", "zh", "zhs", "ru" };
+
+			result = stringmap();
+			result["/entity"] = "/entity_elvis";
+			result["/ui.elvis/texture"] = "/ui.elvis.common/texture";
+
+			for (int i = 0; i < locInfWealthVec.size(); i++)
+			{
+				curLoc = string(locInfWealthVec[i]);
+				result["/db.elvis/" + curLoc] = "/db.elvis." + curLoc;
+				result["/ui.elvis/" + curLoc] = "/ui.elvis." + curLoc;
 			}
 
 			return result;

--- a/source/Maps.h
+++ b/source/Maps.h
@@ -38,7 +38,7 @@ Game getGame(string name)
 	if (startsWith(name, "Yakuza4")) return Game::Yakuza4;
 	if (startsWith(name, "Yakuza5")) return Game::Yakuza5;
 	if (startsWith(name, "Yakuza0")) return Game::Yakuza0;
-	if (startsWith(name, "YakuzaKiwami")) return Game::YakuzaKiwami;
+	if (name == "YakuzaKiwami") return Game::YakuzaKiwami;
 	if (startsWith(name, "Yakuza6")) return Game::Yakuza6;
 	if (startsWith(name, "YakuzaKiwami2")) return Game::YakuzaKiwami2;
 	if (name == "YakuzaLikeADragon") return Game::YakuzaLikeADragon;

--- a/source/Parless.cpp
+++ b/source/Parless.cpp
@@ -773,7 +773,7 @@ void OnInitializeHook()
 	// Rebuild the MLO file
 	if (rebuildMLO)
 	{
-		if (currentGame == Game::Judgment || currentGame == Game::LostJudgment)
+		if (currentGame >= Game::Judgment)
 		{
 			cout << "Not rebuilding MLO because it is unsupported by this game." << endl;
 		}
@@ -1182,7 +1182,8 @@ void OnInitializeHook()
 
 		case Game::LikeADragonGaidenTheManWhoErasedHisName:
 		{
-			hookGaidenAddFileEntry = (t_orgGaidenAddFileEntry*)pattern("48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 38 FE FF FF").get_first(0);
+
+			hookGaidenAddFileEntry = (t_orgGaidenAddFileEntry*)pattern("48 8B C4 4C 89 48 20 89 50 10 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 68 FE FF FF").get_first(0);
 
 			if (MH_CreateHook(hookGaidenAddFileEntry, &GaidenAddFileEntry, reinterpret_cast<LPVOID*>(&orgGaidenAddFileEntry)) != MH_OK)
 			{
@@ -1204,7 +1205,7 @@ void OnInitializeHook()
 		}
 		case Game::LikeADragonInfiniteWealth:
 		{
-			hookIWAddFileEntry = (t_orgIWAddFileEntry*)pattern("48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 38 FE FF FF").get_first(0);
+			hookIWAddFileEntry = (t_orgIWAddFileEntry*)pattern("48 8B C4 4C 89 48 20 89 50 10 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 68 FE FF FF").get_first(0);
 
 			if (MH_CreateHook(hookIWAddFileEntry, &IWAddFileEntry, reinterpret_cast<LPVOID*>(&orgIWAddFileEntry)) != MH_OK)
 			{

--- a/source/Parless.cpp
+++ b/source/Parless.cpp
@@ -28,1146 +28,1236 @@ using namespace std;
 
 namespace Parless
 {
-    const char* VERSION = "1.7.5";
-
-    typedef int (*t_CriBind)(void* param_1, void* param_2, const char* path, void* param_4, int param_5, void* bindId, int param_7);
-    t_CriBind(*hook_BindCpk);
-    t_CriBind org_BindCpk = NULL;
-    t_CriBind org_BindDir = NULL;
+	const char* VERSION = "1.8.0";
 
-    __int64 (*orgY3AddFileEntry)(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12);
-    __int64 (*orgY5AddFileEntry)(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12, int a13, char a14);
-    __int64 (*orgY0AddFileEntry)(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13);
-    int (*orgY6AddFileEntry)(int* param_1, int* param_2, char* param_3);
-    BYTE* (*orgVFeSAddFileEntry)(BYTE* a1, int a2);
+	typedef int (*t_CriBind)(void* param_1, void* param_2, const char* path, void* param_4, int param_5, void* bindId, int param_7);
+	t_CriBind(*hook_BindCpk);
+	t_CriBind org_BindCpk = NULL;
+	t_CriBind org_BindDir = NULL;
 
-    typedef char* (*t_orgYLaDAddFileEntry)(char* a1, uint64_t a2, char* a3, char* a4);
-    t_orgYLaDAddFileEntry orgYLaDAddFileEntry = NULL;
-    t_orgYLaDAddFileEntry (*hookYLaDAddFileEntry) = NULL;
-
-    typedef void (*t_orgYLaDFilepath)(char* a1, uint64_t a2, char* a3, uint64_t a4);
-    t_orgYLaDFilepath orgYLaDFilepath = NULL;
-    t_orgYLaDFilepath(*hookYLaDFilepath) = NULL;
-
-    //t_CriBind(*hookJE_BindCpk) = (t_Bind*)0x141855794;
-    //t_CriBind orgJE_BindDir = (t_Bind)0x141852f3c;
-
-    typedef int (*t_orgLJAddFileEntry)(short* a1, int a2, char* a3, char** a4);
-    t_orgLJAddFileEntry orgLJAddFileEntry = NULL;
-    t_orgLJAddFileEntry(*hookLJAddFileEntry) = NULL;
-
-    __int64 (*orgY3AdxEntry)(__int64 a1, __int64 a2, __int64 a3);
-    __int64 (*orgY0CpkEntry)(__int64 a1, __int64 a2, __int64 a3, __int64 a4);
-    uint64_t(*orgY6SprintfAwb)(uint64_t param_1, uint64_t param_2, uint64_t param_3, uint64_t param_4);
-
-    Game currentGame;
-    Locale currentLocale;
-
-    bool modsLoaded;
-
-    stringmap gameMap;
-    stringmap fileModMap;
-    unordered_map<string, vector<string>> cpkModMap;
-
-    const int DIR_WORKSIZE = 0x58;
-    unordered_map<string, int> cpkBindIdMap;
-
-    unordered_map<string, int> parlessPathMap;
-
-    int gameMapMaxSplits = 3;
-
-    uint8_t STR_LEN_ADD = 0x40;
-
-    string asiPath;
-
-    // Initialized from the INI
-    bool loadMods;
-    bool loadParless;
-    bool rebuildMLO;
-
-    // Mod paths will be relative to the ASI's directory instead of the game's directory (to support undumped UWP games)
-    bool isUwp;
-
-    bool hasRepackedPars;
-
-    class loggingStream {
-      std::mutex m;
-      std::ofstream o;
-    public:
-      explicit loggingStream() {};
-      _Acquires_lock_(this->m) void lock() {
-        this->m.lock();
-      }
-
-      _Releases_lock_(this->m) void unlock() {
-        this->m.unlock();
-      }
-
-      std::ofstream& operator*() {
-        return this->o;
-      }
-
-    };
-
-    // Logging streams
-    loggingStream modOverrides;
-    loggingStream parlessOverrides;
-    loggingStream allFilepaths;
-
-    // Logging variables
-    bool logMods;
-    bool logParless;
-    bool logAll;
-    bool ignoreNonPaths;
-    
-    /// <summary>
-    /// Renames file paths to load files from the mods directory or .parless paths instead of pars.
-    /// </summary>
-    /// <returns>true if the path was overridden</returns>
-    bool RenameFilePaths(char* filepath)
-    {
-        string override = "";
-        bool overridden = false;
-
-        char* datapath;
-        string path(filepath);
-
-        size_t indexOfData = firstIndexOf(path, "data/");
-
-        if (indexOfData == -1 && loadMods)
-        {
-            // File might be in mods instead, which means we're receiving it modified
-            indexOfData = firstIndexOf(path, "mods/");
-
-            if (indexOfData != -1)
-            {
-                // Replace the mod path with data
-                path = removeModPath(path, indexOfData);
-            }
-        }
-
-        if (indexOfData != -1)
-        {
-            vector<int> splits;
-
-            if (loadParless)
-            {
-                // Remove parless if it's there
-                path = removeParlessPath(path, indexOfData);
-            }
-
-            if (!gameMap.empty())
-            {
-                splits = splitPath(path, indexOfData, gameMapMaxSplits);
-                path = translatePath(gameMap, path, splits);
-            }
-
-            if (currentGame >= Game::Yakuza6 && currentGame < Game::YakuzaLikeADragon)
-            {
-                // Dragon Engine specific translation
-                path = translatePathDE(path, indexOfData, currentGame, currentLocale);
-            }
-
-            if (hasRepackedPars && endsWith(path, ".par"))
-            {
-                override = path;
-
-                // Redirect the path from data/ to mods/Parless/
-                override.erase(indexOfData, 4);
-                override.insert(indexOfData, "mods/Parless");
-
-                if (isUwp)
-                {
-                    override = asiPath + override.substr(indexOfData);
-                    indexOfData = asiPath.length();
-                }
-
-                if (filesystem::exists(override))
-                {
-                    overridden = true;
-
-                    override.copy(filepath, override.length());
-                    filepath[override.length()] = '\0';
-
-                    if (logMods)
-                    {
-                        std::lock_guard<loggingStream> g_(modOverrides);
-                        (*modOverrides) << filepath + indexOfData << std::endl;
-                    }
-                }
-                else
-                {
-                    cout << "Par not found: " << override << std::endl;
-                }
-            }
-
-            if (loadParless && !overridden)
-            {
-                int parlessIndex = -1;
-                unordered_map<string, int>::const_iterator parlessPathMatch = parlessPathMap.find(pathWithoutFilename(path).substr(indexOfData + 4));
-
-                if (parlessPathMatch != parlessPathMap.end())
-                {
-                    parlessIndex = parlessPathMatch->second + indexOfData + 4;
-
-                    override = path;
-
-                    // Check if file exists in .parless path
-                    override.insert(parlessIndex, ".parless");
-
-                    if (filesystem::exists(override))
-                    {
-                        overridden = true;
-
-                        override.copy(filepath, override.length());
-                        filepath[override.length()] = '\0';
-
-                        if (logParless)
-                        {
-                            std::lock_guard<loggingStream> g_(parlessOverrides);
-                            (*parlessOverrides) << filepath + indexOfData << std::endl;
-                        }
-                    }
-                    else
-                    {
-                        cout << ".parless file not found: " << override << std::endl;
-                    }
-                }
-            }
-
-            if (loadMods && !overridden)
-            {
-                // Get the path starting from data/
-                string dataPath = path.substr(indexOfData + 4);
-                string dataPath_lowercase = dataPath;
-                std::for_each(dataPath_lowercase.begin(), dataPath_lowercase.end(), [](char& w) { w = std::tolower(w); });
-
-                stringmap::const_iterator match = fileModMap.find(dataPath_lowercase);
-
-                if (match != fileModMap.end())
-                {
-                    override = path;
-
-                    // Redirect the path from data/ to mods/<ModName>/
-                    override.erase(indexOfData, 4);
-                    override.insert(indexOfData, "mods/" + match->second);
-
-                    if (isUwp)
-                    {
-                        override = asiPath + override.substr(indexOfData);
-                        indexOfData = asiPath.length();
-                    }
-
-                    if (filesystem::exists(override))
-                    {
-                        overridden = true;
-
-                        override.copy(filepath, override.length());
-                        filepath[override.length()] = '\0';
-
-                        if (logMods)
-                        {
-                            std::lock_guard<loggingStream> g_(modOverrides);
-                            (*modOverrides) << filepath + indexOfData << std::endl;
-                        }
-                    }
-                    else
-                    {
-                        cout << "Mod file not found: " << override << std::endl;
-                    }
-                }
-            }
-        }
-
-        if (logAll)
-        {
-            if (indexOfData != -1 || !ignoreNonPaths)
-            {
-                if (indexOfData == -1)
-                {
-                    indexOfData = 0;
-                }
-
-                std::lock_guard<loggingStream> g_(allFilepaths);
-                (*allFilepaths) << filepath + indexOfData << std::endl;
-            }
-        }
-
-        return overridden;
-    }
-
-    void BindCpkPaths(void* param_1, void* param_2, const char* filepath, int param_7)
-    {
-        string path(filepath);
-
-        size_t indexOfData = firstIndexOf(path, "data/");
-
-        if (indexOfData == -1 && loadMods)
-        {
-            // File might be in mods instead, which means we're receiving it modified
-            indexOfData = firstIndexOf(path, "mods/");
-
-            if (indexOfData != -1)
-            {
-                // Replace the mod path with data
-                path = removeModPath(path, indexOfData);
-            }
-        }
-
-        if (indexOfData != -1)
-        {
-            vector<int> splits;
-
-            if (loadParless)
-            {
-                // Remove parless if it's there
-                path = removeParlessPath(path, indexOfData);
-            }
-
-            if (!gameMap.empty())
-            {
-                splits = splitPath(path, indexOfData, gameMapMaxSplits);
-                path = translatePath(gameMap, path, splits);
-            }
-
-            if (loadMods)
-            {
-                // Get the path starting from data/
-                string dataPath = path.substr(indexOfData + 4);
-                string dataPath_lowercase = dataPath;
-                std::for_each(dataPath_lowercase.begin(), dataPath_lowercase.end(), [](char& w) { w = std::tolower(w); });
-
-                auto match = cpkModMap.find(dataPath_lowercase);
-                if (match != cpkModMap.end())
-                {
-                    vector<string> modVec = match->second;
-                    for (int i = 0; i < modVec.size(); i++)
-                    {
-                        string override = path;
-
-                        // Redirect the path from data/ to mods/<ModName>/
-                        override.erase(indexOfData, 4);
-                        override.insert(indexOfData, "mods/" + modVec[i]);
-
-                        override.erase(override.size() - 4);
-
-                        auto idMatch = cpkBindIdMap.find(override);
-                        if (idMatch != cpkBindIdMap.end())
-                        {
-                            cout << "Mod CPK directory already bound with ID " << idMatch->second << ": " << override << std::endl;
-                            continue;
-                        }
-
-                        if (filesystem::exists(override))
-                        {
-                            cpkBindIdMap[override] = 0;
-
-                            int result = org_BindDir(param_1, param_2, override.c_str(), malloc(DIR_WORKSIZE), DIR_WORKSIZE, &cpkBindIdMap[override], param_7);
-
-                            if (result != 0)
-                            {
-                                cout << "CRI ERROR: " << result << endl;
-                            }
-
-                            printf_s("Bound directory \"%s\" with ID %d\n", override.c_str() + indexOfData, cpkBindIdMap[override]);
-
-                            if (logMods)
-                            {
-                                std::lock_guard<loggingStream> g_(modOverrides);
-                                (*modOverrides) << override.c_str() + indexOfData << std::endl;
-                            }
-                        }
-                        else
-                        {
-                            cout << "Mod CPK directory not found: " << override << std::endl;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    __int64 Y3AddFileEntry(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12)
-    {
-        RenameFilePaths((char*)filepath);
-        return orgY3AddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
-    }
-
-    __int64 Y3AdxEntry(__int64 filepath, __int64 a2, __int64 a3)
-    {
-        __int64 result = orgY3AdxEntry(filepath, a2, a3);
-        RenameFilePaths((char*)filepath);
-        return result;
-    }
-
-    __int64 Y5AddFileEntry(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12, int a13, char a14)
-    {
-        RenameFilePaths((char*)filepath);
-        return orgY5AddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
-    }
-
-    __int64 Y0AddFileEntry(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13)
-    {
-        RenameFilePaths(filepath);
-        return orgY0AddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
-    }
-
-    __int64 Y0CpkEntry(__int64 a1, __int64 filepath, __int64 a3, __int64 a4)
-    {
-        RenameFilePaths((char*)filepath);
-        return orgY0CpkEntry(a1, filepath, a3, a4);
-    }
-
-    int Y6AddFileEntry(int* a1, int* a2, char* filepath)
-    {
-        RenameFilePaths(filepath);
-        return orgY6AddFileEntry(a1, a2, filepath);
-    }
-
-    uint64_t Y6SprintfAwb(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4)
-    {
-        uint64_t result = orgY6SprintfAwb(a1, a2, a3, a4);
-        RenameFilePaths((char*)result);
-        return result;
-    }
-
-    BYTE* VFeSAddFileEntry(BYTE* a1, int a2)
-    {
-        BYTE* result = orgVFeSAddFileEntry(a1, a2);
-        RenameFilePaths((char*)result);
-        return result;
-    }
-
-    char* YLaDAddFileEntry(char* a1, uint64_t a2, char* a3, char* a4)
-    {
-        char* result = orgYLaDAddFileEntry(a1, a2, a3, a4);
-        RenameFilePaths(a1);
-        return result;
-    }
-
-    int BindCpk(void* param_1, void* param_2, const char* path, void* param_4, int param_5, void* bindId, int param_7)
-    {
-        cout << endl;
-        cout << "Binding CPK: " << path << endl;
-        BindCpkPaths(param_1, param_2, path, param_7);
-        return org_BindCpk(param_1, param_2, path, param_4, param_5, bindId, param_7);
-    }
-
-    int LJAddFileEntry(short* a1, int a2, char* a3, char** a4)
-    {
-        orgLJAddFileEntry(a1, a2, a3, a4);
-        RenameFilePaths((char*)a1);
-        return strlen((char*)a1);
-    }
-
-    void YLaDFilepath(char* a1, uint64_t a2, char* a3, uint64_t a4)
-    {
-        RenameFilePaths(a3);
-        orgYLaDFilepath(a1, a2, a3, a4);
-    }
+	__int64 (*orgY3AddFileEntry)(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12);
+	__int64 (*orgY5AddFileEntry)(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12, int a13, char a14);
+	__int64 (*orgY0AddFileEntry)(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13);
+	int (*orgY6AddFileEntry)(int* param_1, int* param_2, char* param_3);
+	BYTE* (*orgVFeSAddFileEntry)(BYTE* a1, int a2);
+
+	typedef char* (*t_orgYLaDAddFileEntry)(char* a1, uint64_t a2, char* a3, char* a4);
+	t_orgYLaDAddFileEntry orgYLaDAddFileEntry = NULL;
+	t_orgYLaDAddFileEntry(*hookYLaDAddFileEntry) = NULL;
+
+	typedef void (*t_orgYLaDFilepath)(char* a1, uint64_t a2, char* a3, uint64_t a4);
+	t_orgYLaDFilepath orgYLaDFilepath = NULL;
+	t_orgYLaDFilepath(*hookYLaDFilepath) = NULL;
+
+	//t_CriBind(*hookJE_BindCpk) = (t_Bind*)0x141855794;
+	//t_CriBind orgJE_BindDir = (t_Bind)0x141852f3c;
+
+	typedef int (*t_orgLJAddFileEntry)(short* a1, int a2, char* a3, char** a4);
+	t_orgLJAddFileEntry orgLJAddFileEntry = NULL;
+	t_orgLJAddFileEntry(*hookLJAddFileEntry) = NULL;
+
+	typedef int (*t_orgGaidenAddFileEntry)(short* a1, int a2, char* a3, char** a4);
+	t_orgGaidenAddFileEntry orgGaidenAddFileEntry = NULL;
+	t_orgGaidenAddFileEntry(*hookGaidenAddFileEntry) = NULL;
+
+	typedef void* (*t_orgIWAddFileEntry)(short* a1, int a2, char* a3, char** a4);
+	t_orgIWAddFileEntry orgIWAddFileEntry = NULL;
+	t_orgIWAddFileEntry(*hookIWAddFileEntry) = NULL;
+
+	__int64 (*orgY3AdxEntry)(__int64 a1, __int64 a2, __int64 a3);
+	__int64 (*orgY0CpkEntry)(__int64 a1, __int64 a2, __int64 a3, __int64 a4);
+	uint64_t(*orgY6SprintfAwb)(uint64_t param_1, uint64_t param_2, uint64_t param_3, uint64_t param_4);
+
+	typedef bool (*t_DEIsDemo)();
+
+	Game currentGame;
+	Locale currentLocale;
+
+	bool isDemo;
+
+	bool modsLoaded;
+
+	stringmap gameMap;
+	stringmap fileModMap;
+	unordered_map<string, vector<string>> cpkModMap;
+
+	const int DIR_WORKSIZE = 0x58;
+	unordered_map<string, int> cpkBindIdMap;
+
+	unordered_map<string, int> parlessPathMap;
+
+	int gameMapMaxSplits = 3;
+
+	uint8_t STR_LEN_ADD = 0x40;
+
+	string asiPath;
+
+	// Initialized from the INI
+	bool loadMods;
+	bool loadParless;
+	bool rebuildMLO;
+
+	// Mod paths will be relative to the ASI's directory instead of the game's directory (to support undumped UWP games)
+	bool isUwp;
+
+	bool hasRepackedPars;
+
+	class loggingStream {
+		std::mutex m;
+		std::ofstream o;
+	public:
+		explicit loggingStream() {};
+		_Acquires_lock_(this->m) void lock() {
+			this->m.lock();
+		}
+
+		_Releases_lock_(this->m) void unlock() {
+			this->m.unlock();
+		}
+
+		std::ofstream& operator*() {
+			return this->o;
+		}
+
+	};
+
+	// Logging streams
+	loggingStream modOverrides;
+	loggingStream parlessOverrides;
+	loggingStream allFilepaths;
+
+	// Logging variables
+	bool logMods;
+	bool logParless;
+	bool logAll;
+	bool ignoreNonPaths;
+
+	/// <summary>
+	/// Renames file paths to load files from the mods directory or .parless paths instead of pars.
+	/// </summary>
+	/// <returns>true if the path was overridden</returns>
+	bool RenameFilePaths(char* filepath)
+	{
+		string override = "";
+		bool overridden = false;
+
+		char* datapath;
+		string path(filepath);
+
+		size_t indexOfData = firstIndexOf(path, "data/");
+
+		if (indexOfData == -1 && loadMods)
+		{
+			// File might be in mods instead, which means we're receiving it modified
+			indexOfData = firstIndexOf(path, "mods/");
+
+			if (indexOfData != -1)
+			{
+				// Replace the mod path with data
+				path = removeModPath(path, indexOfData);
+			}
+		}
+
+		if (indexOfData != -1)
+		{
+			vector<int> splits;
+
+			if (loadParless)
+			{
+				// Remove parless if it's there
+				path = removeParlessPath(path, indexOfData);
+			}
+
+			if (!gameMap.empty())
+			{
+				splits = splitPath(path, indexOfData, gameMapMaxSplits);
+				path = translatePath(gameMap, path, splits);
+			}
+
+			if (currentGame >= Game::Yakuza6 && currentGame < Game::YakuzaLikeADragon)
+			{
+				// Dragon Engine specific translation
+				path = translatePathDE(path, indexOfData, currentGame, currentLocale);
+			}
+
+			if (hasRepackedPars && endsWith(path, ".par"))
+			{
+				override = path;
+
+				// Redirect the path from data/ to mods/Parless/
+				override.erase(indexOfData, 4);
+				override.insert(indexOfData, "mods/Parless");
+
+				if (isUwp)
+				{
+					override = asiPath + override.substr(indexOfData);
+					indexOfData = asiPath.length();
+				}
+
+				if (filesystem::exists(override))
+				{
+					overridden = true;
+
+					override.copy(filepath, override.length());
+					filepath[override.length()] = '\0';
+
+					if (logMods)
+					{
+						std::lock_guard<loggingStream> g_(modOverrides);
+						(*modOverrides) << filepath + indexOfData << std::endl;
+					}
+				}
+				else
+				{
+					cout << "Par not found: " << override << std::endl;
+				}
+			}
+
+			if (loadParless && !overridden)
+			{
+				int parlessIndex = -1;
+				unordered_map<string, int>::const_iterator parlessPathMatch = parlessPathMap.find(pathWithoutFilename(path).substr(indexOfData + 4));
+
+				if (parlessPathMatch != parlessPathMap.end())
+				{
+					parlessIndex = parlessPathMatch->second + indexOfData + 4;
+
+					override = path;
+
+					// Check if file exists in .parless path
+					override.insert(parlessIndex, ".parless");
+
+					if (filesystem::exists(override))
+					{
+						overridden = true;
+
+						override.copy(filepath, override.length());
+						filepath[override.length()] = '\0';
+
+						if (logParless)
+						{
+							std::lock_guard<loggingStream> g_(parlessOverrides);
+							(*parlessOverrides) << filepath + indexOfData << std::endl;
+						}
+					}
+					else
+					{
+						cout << ".parless file not found: " << override << std::endl;
+					}
+				}
+			}
+
+			if (loadMods && !overridden)
+			{
+				// Get the path starting from data/
+				string dataPath = path.substr(indexOfData + 4);
+				string dataPath_lowercase = dataPath;
+				std::for_each(dataPath_lowercase.begin(), dataPath_lowercase.end(), [](char& w) { w = std::tolower(w); });
+
+				stringmap::const_iterator match = fileModMap.find(dataPath_lowercase);
+
+				if (match != fileModMap.end())
+				{
+					override = path;
+
+					// Redirect the path from data/ to mods/<ModName>/
+					override.erase(indexOfData, 4);
+					override.insert(indexOfData, "mods/" + match->second);
+
+					if (isUwp)
+					{
+						override = asiPath + override.substr(indexOfData);
+						indexOfData = asiPath.length();
+					}
+
+					if (filesystem::exists(override))
+					{
+						overridden = true;
+
+						override.copy(filepath, override.length());
+						filepath[override.length()] = '\0';
+
+						if (logMods)
+						{
+							std::lock_guard<loggingStream> g_(modOverrides);
+							(*modOverrides) << filepath + indexOfData << std::endl;
+						}
+					}
+					else
+					{
+						cout << "Mod file not found: " << override << std::endl;
+					}
+				}
+			}
+		}
+
+		if (logAll)
+		{
+			if (indexOfData != -1 || !ignoreNonPaths)
+			{
+				if (indexOfData == -1)
+				{
+					indexOfData = 0;
+				}
+
+				std::lock_guard<loggingStream> g_(allFilepaths);
+				(*allFilepaths) << filepath + indexOfData << std::endl;
+			}
+		}
+
+		return overridden;
+	}
+
+	void BindCpkPaths(void* param_1, void* param_2, const char* filepath, int param_7)
+	{
+		string path(filepath);
+
+		size_t indexOfData = firstIndexOf(path, "data/");
+
+		if (indexOfData == -1 && loadMods)
+		{
+			// File might be in mods instead, which means we're receiving it modified
+			indexOfData = firstIndexOf(path, "mods/");
+
+			if (indexOfData != -1)
+			{
+				// Replace the mod path with data
+				path = removeModPath(path, indexOfData);
+			}
+		}
+
+		if (indexOfData != -1)
+		{
+			vector<int> splits;
+
+			if (loadParless)
+			{
+				// Remove parless if it's there
+				path = removeParlessPath(path, indexOfData);
+			}
+
+			if (!gameMap.empty())
+			{
+				splits = splitPath(path, indexOfData, gameMapMaxSplits);
+				path = translatePath(gameMap, path, splits);
+			}
+
+			if (loadMods)
+			{
+				// Get the path starting from data/
+				string dataPath = path.substr(indexOfData + 4);
+				string dataPath_lowercase = dataPath;
+				std::for_each(dataPath_lowercase.begin(), dataPath_lowercase.end(), [](char& w) { w = std::tolower(w); });
+
+				auto match = cpkModMap.find(dataPath_lowercase);
+				if (match != cpkModMap.end())
+				{
+					vector<string> modVec = match->second;
+					for (int i = 0; i < modVec.size(); i++)
+					{
+						string override = path;
+
+						// Redirect the path from data/ to mods/<ModName>/
+						override.erase(indexOfData, 4);
+						override.insert(indexOfData, "mods/" + modVec[i]);
+
+						override.erase(override.size() - 4);
+
+						auto idMatch = cpkBindIdMap.find(override);
+						if (idMatch != cpkBindIdMap.end())
+						{
+							cout << "Mod CPK directory already bound with ID " << idMatch->second << ": " << override << std::endl;
+							continue;
+						}
+
+						if (filesystem::exists(override))
+						{
+							cpkBindIdMap[override] = 0;
+
+							int result = org_BindDir(param_1, param_2, override.c_str(), malloc(DIR_WORKSIZE), DIR_WORKSIZE, &cpkBindIdMap[override], param_7);
+
+							if (result != 0)
+							{
+								cout << "CRI ERROR: " << result << endl;
+							}
+
+							printf_s("Bound directory \"%s\" with ID %d\n", override.c_str() + indexOfData, cpkBindIdMap[override]);
+
+							if (logMods)
+							{
+								std::lock_guard<loggingStream> g_(modOverrides);
+								(*modOverrides) << override.c_str() + indexOfData << std::endl;
+							}
+						}
+						else
+						{
+							cout << "Mod CPK directory not found: " << override << std::endl;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	__int64 Y3AddFileEntry(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12)
+	{
+		RenameFilePaths((char*)filepath);
+		return orgY3AddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
+	}
+
+	__int64 Y3AdxEntry(__int64 filepath, __int64 a2, __int64 a3)
+	{
+		__int64 result = orgY3AdxEntry(filepath, a2, a3);
+		RenameFilePaths((char*)filepath);
+		return result;
+	}
+
+	__int64 Y5AddFileEntry(__int64 a1, __int64 filepath, __int64 a3, int a4, __int64 a5, __int64 a6, int a7, __int64 a8, int a9, char a10, int a11, char a12, int a13, char a14)
+	{
+		RenameFilePaths((char*)filepath);
+		return orgY5AddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
+	}
+
+	__int64 Y0AddFileEntry(__int64 a1, char* filepath, __int64 a3, int a4, __int64 a5, __int64 a6, char a7, __int64 a8, char a9, char a10, char a11, char a12, char a13)
+	{
+		RenameFilePaths(filepath);
+		return orgY0AddFileEntry(a1, filepath, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
+	}
+
+	__int64 Y0CpkEntry(__int64 a1, __int64 filepath, __int64 a3, __int64 a4)
+	{
+		RenameFilePaths((char*)filepath);
+		return orgY0CpkEntry(a1, filepath, a3, a4);
+	}
+
+	int Y6AddFileEntry(int* a1, int* a2, char* filepath)
+	{
+		RenameFilePaths(filepath);
+		return orgY6AddFileEntry(a1, a2, filepath);
+	}
+
+	uint64_t Y6SprintfAwb(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4)
+	{
+		uint64_t result = orgY6SprintfAwb(a1, a2, a3, a4);
+		RenameFilePaths((char*)result);
+		return result;
+	}
+
+	BYTE* VFeSAddFileEntry(BYTE* a1, int a2)
+	{
+		BYTE* result = orgVFeSAddFileEntry(a1, a2);
+		RenameFilePaths((char*)result);
+		return result;
+	}
+
+	char* YLaDAddFileEntry(char* a1, uint64_t a2, char* a3, char* a4)
+	{
+		char* result = orgYLaDAddFileEntry(a1, a2, a3, a4);
+		RenameFilePaths(a1);
+		return result;
+	}
+
+	int BindCpk(void* param_1, void* param_2, const char* path, void* param_4, int param_5, void* bindId, int param_7)
+	{
+		cout << endl;
+		cout << "Binding CPK: " << path << endl;
+		BindCpkPaths(param_1, param_2, path, param_7);
+		return org_BindCpk(param_1, param_2, path, param_4, param_5, bindId, param_7);
+	}
+
+	int LJAddFileEntry(short* a1, int a2, char* a3, char** a4)
+	{
+		orgLJAddFileEntry(a1, a2, a3, a4);
+		RenameFilePaths((char*)a1);
+		return strlen((char*)a1);
+	}
+
+	int GaidenAddFileEntry(short* a1, int a2, char* a3, char** a4)
+	{
+		orgGaidenAddFileEntry(a1, a2, a3, a4);
+		RenameFilePaths((char*)a1);
+		return strlen((char*)a1);
+	}
+
+	int IWAddFileEntry(short* a1, int a2, char* a3, char** a4)
+	{
+		orgIWAddFileEntry(a1, a2, a3, a4);
+		RenameFilePaths((char*)a1);
+		return strlen((char*)a1);
+	}
+
+	void YLaDFilepath(char* a1, uint64_t a2, char* a3, uint64_t a4)
+	{
+		RenameFilePaths(a3);
+		orgYLaDFilepath(a1, a2, a3, a4);
+	}
 }
 
 void RebuildMLO()
 {
-    SHELLEXECUTEINFOA ShExecInfo = { 0 };
-    ShExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);
-    ShExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
-    ShExecInfo.hwnd = NULL;
-    ShExecInfo.lpVerb = NULL;
-    ShExecInfo.lpFile = "RyuModManager.exe";
-    ShExecInfo.lpParameters = "-s";
-    ShExecInfo.lpDirectory = NULL;
-    ShExecInfo.nShow = SW_HIDE;
-    ShExecInfo.hInstApp = NULL;
-    ShellExecuteExA(&ShExecInfo);
-    WaitForSingleObject(ShExecInfo.hProcess, INFINITE);
-    CloseHandle(ShExecInfo.hProcess);
+	SHELLEXECUTEINFOA ShExecInfo = { 0 };
+	ShExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);
+	ShExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
+	ShExecInfo.hwnd = NULL;
+	ShExecInfo.lpVerb = NULL;
+	ShExecInfo.lpFile = "RyuModManager.exe";
+	ShExecInfo.lpParameters = "-s";
+	ShExecInfo.lpDirectory = NULL;
+	ShExecInfo.nShow = SW_HIDE;
+	ShExecInfo.hInstApp = NULL;
+	ShellExecuteExA(&ShExecInfo);
+	WaitForSingleObject(ShExecInfo.hProcess, INFINITE);
+	CloseHandle(ShExecInfo.hProcess);
 }
 
 void ReadModLoadOrder()
 {
-    using namespace Parless;
+	using namespace Parless;
 
-    const char* MLO_MAGIC = "_OLM";
-    string MLO_FILE = asiPath + "/YakuzaParless.mlo";
+	const char* MLO_MAGIC = "_OLM";
+	string MLO_FILE = asiPath + "/YakuzaParless.mlo";
 
-    if (!filesystem::exists(MLO_FILE))
-        return;
+	if (!filesystem::exists(MLO_FILE))
+		return;
 
-    ifstream mlo(MLO_FILE, ios::binary | ios::in);
+	ifstream mlo(MLO_FILE, ios::binary | ios::in);
 
-    if (!mlo)
-        return;
+	if (!mlo)
+		return;
 
-    char magic[5];
-    mlo.read(magic, 4);
-    magic[4] = '\0';
+	char magic[5];
+	mlo.read(magic, 4);
+	magic[4] = '\0';
 
-    if (strcmp(magic, MLO_MAGIC))
-        return;
+	if (strcmp(magic, MLO_MAGIC))
+		return;
 
-    // Skip endianness
-    mlo.seekg(4, SEEK_CUR);
+	// Skip endianness
+	mlo.seekg(4, SEEK_CUR);
 
-    uint32_t version;
-    mlo.read((char*)&version, sizeof(version));
+	uint32_t version;
+	mlo.read((char*)&version, sizeof(version));
 
-    // Skip filesize
-    mlo.seekg(4, SEEK_CUR);
+	// Skip filesize
+	mlo.seekg(4, SEEK_CUR);
 
-    if (version == 0x20000)
-    {
-        uint32_t modNameStart;
-        uint32_t modCount;
+	if (version == 0x20000)
+	{
+		uint32_t modNameStart;
+		uint32_t modCount;
 
-        uint32_t fileNameStart;
-        uint32_t fileCount;
+		uint32_t fileNameStart;
+		uint32_t fileCount;
 
-        uint32_t parlessPathStart;
-        uint32_t parlessPathCount;
+		uint32_t parlessPathStart;
+		uint32_t parlessPathCount;
 
-        uint32_t cpkFolderStart;
-        uint32_t cpkFolderCount;
+		uint32_t cpkFolderStart;
+		uint32_t cpkFolderCount;
 
-        mlo.read((char*)&modNameStart, sizeof(modNameStart));
-        mlo.read((char*)&modCount, sizeof(modCount));
+		mlo.read((char*)&modNameStart, sizeof(modNameStart));
+		mlo.read((char*)&modCount, sizeof(modCount));
 
-        mlo.read((char*)&fileNameStart, sizeof(fileNameStart));
-        mlo.read((char*)&fileCount, sizeof(fileCount));
+		mlo.read((char*)&fileNameStart, sizeof(fileNameStart));
+		mlo.read((char*)&fileCount, sizeof(fileCount));
 
-        mlo.read((char*)&parlessPathStart, sizeof(parlessPathStart));
-        mlo.read((char*)&parlessPathCount, sizeof(parlessPathCount));
+		mlo.read((char*)&parlessPathStart, sizeof(parlessPathStart));
+		mlo.read((char*)&parlessPathCount, sizeof(parlessPathCount));
 
-        mlo.read((char*)&cpkFolderStart, sizeof(cpkFolderStart));
-        mlo.read((char*)&cpkFolderCount, sizeof(cpkFolderCount));
+		mlo.read((char*)&cpkFolderStart, sizeof(cpkFolderStart));
+		mlo.read((char*)&cpkFolderCount, sizeof(cpkFolderCount));
 
-        // Skip padding
-        mlo.seekg(0x10, SEEK_CUR);
+		// Skip padding
+		mlo.seekg(0x10, SEEK_CUR);
 
-        uint16_t length;
-        char* name;
+		uint16_t length;
+		char* name;
 
-        mlo.seekg(modNameStart);
+		mlo.seekg(modNameStart);
 
-        vector<string> mods;
-        for (int i = 0; i < modCount; i++)
-        {
-            mlo.read((char*)&length, sizeof(length));
+		vector<string> mods;
+		for (int i = 0; i < modCount; i++)
+		{
+			mlo.read((char*)&length, sizeof(length));
 
-            name = new char[length];
-            mlo.read(name, length);
+			name = new char[length];
+			mlo.read(name, length);
 
-            mods.push_back(string(name));
-            delete[] name;
-        }
+			mods.push_back(string(name));
+			delete[] name;
+		}
 
-        mlo.seekg(fileNameStart);
+		mlo.seekg(fileNameStart);
 
-        uint16_t index;
-        for (int i = 0; i < fileCount; i++)
-        {
-            mlo.read((char*)&index, sizeof(index));
-            mlo.read((char*)&length, sizeof(length));
+		uint16_t index;
+		for (int i = 0; i < fileCount; i++)
+		{
+			mlo.read((char*)&index, sizeof(index));
+			mlo.read((char*)&length, sizeof(length));
 
-            name = new char[length];
-            mlo.read(name, length);
+			name = new char[length];
+			mlo.read(name, length);
 
-            fileModMap[string(name)] = mods[index];
-            delete[] name;
-        }
+			fileModMap[string(name)] = mods[index];
+			delete[] name;
+		}
 
-        mlo.seekg(parlessPathStart);
+		mlo.seekg(parlessPathStart);
 
-        for (int i = 0; i < parlessPathCount; i++)
-        {
-            mlo.read((char*)&index, sizeof(index));
-            mlo.read((char*)&length, sizeof(length));
+		for (int i = 0; i < parlessPathCount; i++)
+		{
+			mlo.read((char*)&index, sizeof(index));
+			mlo.read((char*)&length, sizeof(length));
 
-            name = new char[length];
-            mlo.read(name, length);
+			name = new char[length];
+			mlo.read(name, length);
 
-            parlessPathMap[string(name)] = index;
-            delete[] name;
-        }
+			parlessPathMap[string(name)] = index;
+			delete[] name;
+		}
 
-        mlo.seekg(cpkFolderStart);
+		mlo.seekg(cpkFolderStart);
 
-        uint16_t count;
-        for (int i = 0; i < fileCount; i++)
-        {
-            mlo.read((char*)&count, sizeof(count));
-            mlo.read((char*)&length, sizeof(length));
+		uint16_t count;
+		for (int i = 0; i < fileCount; i++)
+		{
+			mlo.read((char*)&count, sizeof(count));
+			mlo.read((char*)&length, sizeof(length));
 
-            name = new char[length];
-            mlo.read(name, length);
+			name = new char[length];
+			mlo.read(name, length);
 
-            vector<string> modIndices;
-            for (int j = 0; j < count; j++)
-            {
-                mlo.read((char*)&index, sizeof(index));
-                modIndices.push_back(mods[index]);
-            }
+			vector<string> modIndices;
+			for (int j = 0; j < count; j++)
+			{
+				mlo.read((char*)&index, sizeof(index));
+				modIndices.push_back(mods[index]);
+			}
 
-            cpkModMap[string(name)] = modIndices;
-            delete[] name;
-        }
-        
-    }
+			cpkModMap[string(name)] = modIndices;
+			delete[] name;
+		}
+
+	}
 }
 
 void InitializeScripts()
 {
-    typedef int(__stdcall* asi_init)();
+	typedef int(__stdcall* asi_init)();
 
-    //Iterate the filemap for any ASI scripts. Then load them
-    for (auto it = Parless::fileModMap.begin(); it != Parless::fileModMap.end(); it++) {
+	//Iterate the filemap for any ASI scripts. Then load them
+	for (auto it = Parless::fileModMap.begin(); it != Parless::fileModMap.end(); it++) {
 
-        if (endsWith(it->first, ".asi"))
-        {
-            string path;
-            path += string("mods/") + string(it->second) + string(it->first);
+		if (endsWith(it->first, ".asi"))
+		{
+			string path;
+			path += string("mods/") + string(it->second) + string(it->first);
 
-            HINSTANCE asiScript = LoadLibraryA(path.c_str());
+			HINSTANCE asiScript = LoadLibraryA(path.c_str());
 
-            if (asiScript)
-            {
-                asi_init asiInitFunc = (asi_init)GetProcAddress(asiScript, "InitializeASI");
+			if (asiScript)
+			{
+				asi_init asiInitFunc = (asi_init)GetProcAddress(asiScript, "InitializeASI");
 
-                if (asiInitFunc)
-                    asiInitFunc();
-            }
-            else
-                cout << "Script LoadLibrary fail: " << path.c_str() << " Error Code: " << GetLastError() << endl;
-        }
-    }
+				if (asiInitFunc)
+					asiInitFunc();
+			}
+			else
+				cout << "Script LoadLibrary fail: " << path.c_str() << " Error Code: " << GetLastError() << endl;
+		}
+	}
+}
+
+bool shouldCreateTrampoline()
+{
+	//Prevents initialization for some reason
+	if (Parless::currentGame >= Game::LikeADragonGaidenTheManWhoErasedHisName)
+		return false;
+
+	return true;
 }
 
 void OnInitializeHook()
 {
-    std::unique_ptr<ScopedUnprotect::Unprotect> Protect = ScopedUnprotect::UnprotectSectionOrFullModule(GetModuleHandle(nullptr), ".text");
-
-    using namespace Memory::VP;
-    using namespace hook;
-
-    using namespace Parless;
-
-    const char* FILE_LOAD_MSG = "Applied file loading hook.\n";
-    const char* CPK_LOAD_MSG = "Applied CPK loading hook.\n";
-    const char* CPK_BIND_MSG = "Applied CPK directory bind hook.\n";
-    const char* ADX_LOAD_MSG = "Applied ADX loading hook.\n";
-    const char* AWB_LOAD_MSG = "Applied AWB loading hook.\n";
-    const char* PATH_EXT_MSG = "Applied file path extension hook.\n";
-
-    // Read INI variables
-
-    // Obtain a path to the ASI
-    wchar_t wcModulePath[MAX_PATH];
-    GetModuleFileNameW(hDLLModule, wcModulePath, _countof(wcModulePath) - 3); // Minus max required space for extension
-    PathRenameExtensionW(wcModulePath, L".ini");
-
-    // Store the ASI's path for later
-    wstring asiPathW(wcModulePath);
-    asiPath = string(asiPathW.begin(), asiPathW.end());
-    replace(asiPath.begin(), asiPath.end(), '\\', '/');
-    asiPath = pathWithoutFilename(asiPath);
-
-    if (GetPrivateProfileIntW(L"Parless", L"TempDisabled", 0, wcModulePath))
-    {
-        WritePrivateProfileStringW(L"Parless", L"TempDisabled", L"0", wcModulePath);
-        return;
-    }
-
-    if (GetPrivateProfileIntW(L"Parless", L"ParlessEnabled", 1, wcModulePath) == 0)
-    {
-        return;
-    }
-
-    // LooseFilesEnabled is set to 0 by default in the INI
-    loadParless = GetPrivateProfileIntW(L"Overrides", L"LooseFilesEnabled ", 1, wcModulePath);
-    loadMods = GetPrivateProfileIntW(L"Overrides", L"ModsEnabled", 1, wcModulePath);
-    rebuildMLO = GetPrivateProfileIntW(L"Overrides", L"RebuildMLO", 0, wcModulePath);
-
-    int localeValue = GetPrivateProfileIntW(L"Overrides", L"Locale", 0, wcModulePath);
-
-    logMods = GetPrivateProfileIntW(L"Logs", L"LogMods", 0, wcModulePath);
-    logParless = GetPrivateProfileIntW(L"Logs", L"LogParless", 0, wcModulePath);
-    logAll = GetPrivateProfileIntW(L"Logs", L"LogAll", 0, wcModulePath);
-    ignoreNonPaths = GetPrivateProfileIntW(L"Logs", L"IgnoreNonPaths", 1, wcModulePath);
-
-    isUwp = GetPrivateProfileIntW(L"UWP", L"UWPGame", -1, wcModulePath) != -1;
-
-    if (GetPrivateProfileIntW(L"Debug", L"ConsoleEnabled", 0, wcModulePath))
-    {
-        // Open debugging console
-        AllocConsole();
-        FILE* fDummy;
-        freopen_s(&fDummy, "CONOUT$", "w", stdout);
-    }
-
-    // Get the name of the current game
-    wchar_t exePath[MAX_PATH + 1];
-    GetModuleFileNameW(NULL, exePath, MAX_PATH);
-
-    wstring wstr(exePath);
-    string currentGameName = basenameBackslashNoExt(string(wstr.begin(), wstr.end()));
-
-    currentGame = getGame(currentGameName);
-    currentGameName = getGameName(currentGame);
-    currentLocale = localeValue < 4 && localeValue >= 0 ? Locale(localeValue) : Locale::English;
-
-    cout << "YakuzaParless v" << VERSION << "\n\n";
-    cout << "Detected game: " << currentGameName << (isUwp ? " UWP version" : "") << endl;
-
-    if (currentGame == Game::Unsupported)
-    {
-        cout << currentGameName << " is unsupported. Aborting." << endl;
-        return;
-    }
-
-    Trampoline* trampoline = Trampoline::MakeTrampoline(GetModuleHandle(nullptr));
-
-    // Initialize the virtual->real map
-    gameMap = getGameMap(currentGame, currentLocale);
-
-    // Rebuild the MLO file
-    if (rebuildMLO)
-    {
-        if (currentGame == Game::Judgment || currentGame == Game::LostJudgment)
-        {
-            cout << "Not rebuilding MLO because it is unsupported by this game." << endl;
-        }
-        else
-        {
-            cout << "Rebuilding MLO... ";
-            RebuildMLO();
-            cout << "DONE!\n";
-        }
-    }
-
-    // Read MLO file
-    cout << "Reading MLO... ";
-    ReadModLoadOrder();
-    cout << "DONE!\n";
-    
-    //Initialize Extensions/Script Mods
-    cout << "Initializing mod scripts... ";
-    InitializeScripts();
-    cout << "DONE!\n";
-
-    // These maps are filled after reading the MLO
-    if (!parlessPathMap.size())
-    {
-        cout << "No \".parless\" paths were found in the MLO.\n";
-        loadParless = false;
-    }
-    if (!fileModMap.size())
-    {
-        cout << "No mod files were found in the MLO.\n";
-        loadMods = false;
-    }
-
-    // Check if repacked pars exist (old engine only)
-    hasRepackedPars = filesystem::is_directory("mods/Parless");
-
-    if (!hasRepackedPars)
-    {
-        cout << "No repacked pars were found.\n";
-    }
-
-    cout << endl;
-
-    if (!(loadParless || loadMods || hasRepackedPars || logAll))
-    {
-        cout << "No mods were loaded. LogAll is disabled. No patches will be applied. Aborting.\n";
-    }
-    else
-    {
-        char pathToLog[MAX_PATH];
-
-        // Open log streams if logging is enabled, remove them otherwise
-        asiPath.copy(pathToLog, asiPath.length());
-        pathToLog[asiPath.length()] = '\0';
-        strcat_s(pathToLog, "/modOverrides.txt");
-        if (logMods) (*modOverrides).open(pathToLog, ios::out);
-        else remove(pathToLog);
-
-        asiPath.copy(pathToLog, asiPath.length());
-        pathToLog[asiPath.length()] = '\0';
-        strcat_s(pathToLog, "/parlessOverrides.txt");
-        if (logParless && loadParless) (*parlessOverrides).open(pathToLog, ios::out);
-        else remove(pathToLog);
-
-        asiPath.copy(pathToLog, asiPath.length());
-        pathToLog[asiPath.length()] = '\0';
-        strcat_s(pathToLog, "/allFilespaths.txt");
-        if (logAll) (*allFilepaths).open(pathToLog, ios::out);
-        else remove(pathToLog);
-
-        void* renameFilePathsFunc;
-
-        if (MH_Initialize() != MH_OK)
-        {
-            cout << "Minhook initialization failed. Aborting.\n";
-            return;
-        }
-
-        switch (currentGame)
-        {
-            case Game::Yakuza0:
-            case Game::YakuzaKiwami:
-                // might want to hook the other call of this function as well, but currently not necessary (?)
-                renameFilePathsFunc = get_pattern("48 89 44 24 20 48 8B D5 48 8B 0D ? ? ? ?", 15);
-                ReadCall(renameFilePathsFunc, orgY0AddFileEntry);
-
-                // this will take care of every file that is read from disk
-                InjectHook(renameFilePathsFunc, trampoline->Jump(Y0AddFileEntry));
-                cout << FILE_LOAD_MSG;
-
-                // Cpk
-                if (currentGame == Game::Yakuza0)
-                {
-                    renameFilePathsFunc = get_pattern("8B 4D D7 4A 8D 74 28 20 48 83 E6 E0 48 8D BE 9F 02 00 00", -13);
-                    ReadCall(renameFilePathsFunc, orgY0CpkEntry);
-
-                    InjectHook(renameFilePathsFunc, trampoline->Jump(Y0CpkEntry));
-                }
-                else
-                {
-                    // Yakuza Kiwami
-                    renameFilePathsFunc = get_pattern("8B 4D DF 48 8D 70 20 49 03 F6 48 83 E6 E0", -13);
-                    ReadCall(renameFilePathsFunc, orgY0CpkEntry);
-
-                    InjectHook(renameFilePathsFunc, trampoline->Jump(Y0CpkEntry));
-                }
-
-                cout << CPK_LOAD_MSG;
-
-                break;
-            case Game::Yakuza3:
-            case Game::Yakuza4:
-                renameFilePathsFunc = get_pattern("66 89 83 44 02 00 00 E8 ? ? ? ? 48 8B C3 48 8B 8C 24 A0 03 00 00", -5);
-                ReadCall(renameFilePathsFunc, orgY3AddFileEntry);
-
-                InjectHook(renameFilePathsFunc, trampoline->Jump(Y3AddFileEntry));
-                cout << FILE_LOAD_MSG;
-
-                // Adx
-                renameFilePathsFunc = get_pattern("48 89 5C 24 18 57 48 81 EC 90 06 00 00 48 8B 05", 0x84);
-                ReadCall(renameFilePathsFunc, orgY3AdxEntry);
-
-                InjectHook(renameFilePathsFunc, trampoline->Jump(Y3AdxEntry));
-                cout << ADX_LOAD_MSG;
-                break;
-            case Game::Yakuza5:
-                renameFilePathsFunc = get_pattern("48 89 4C 24 20 49 8B D7 48 8B 0D ? ? ? ?", 15);
-                ReadCall(renameFilePathsFunc, orgY5AddFileEntry);
-
-                InjectHook(renameFilePathsFunc, trampoline->Jump(Y5AddFileEntry));
-                cout << FILE_LOAD_MSG;
-
-                hook_BindCpk = (t_CriBind*)get_pattern("41 57 48 8B EC 48 83 EC 70 4C 8B 6D 58 33 DB", -26);
-                org_BindDir = (t_CriBind)get_pattern("41 57 48 83 EC 30 48 8B 74 24 78 33 ED", -23);
-
-                if (MH_CreateHook(hook_BindCpk, &BindCpk, reinterpret_cast<LPVOID*>(&org_BindCpk)) != MH_OK)
-                {
-                    cout << "Hook creation failed. Aborting.\n";
-                    return;
-                }
-
-                if (MH_EnableHook(hook_BindCpk) != MH_OK)
-                {
-                    cout << "Hook could not be enabled. Aborting.\n";
-                    return;
-                }
-
-                org_BindCpk = (t_CriBind)((char*)org_BindCpk + 1);
-
-                cout << CPK_BIND_MSG;
-                break;
-            case Game::Yakuza6:
-            {
-                // Hook inside the method that calculates a string's length to add 0x20 bytes to the length
-                // This is needed to prevent undefined behavior when the modified path is longer than the memory allocated to it
-                auto stringLenAddr = get_pattern("8B CD 3B D9 77 47", -0x1C);
-
-                Trampoline* trampolineStringLen = Trampoline::MakeTrampoline(stringLenAddr);
-
-                const uint8_t spacePayload[] = {
-                    0x48, 0x03, 0xD8, // add rbx, rax
-                    0x2B, 0xDE, // sub ebx, esi
-                    0x48, 0x83, 0xC3, STR_LEN_ADD, // add rbx, 0x20
-                    0x48, 0x8B, 0x07, // mov rax, qword ptr ds:[rdi]
-                    0xE9, 0x0, 0x0, 0x0, 0x0 // jmp stringLenAddr+8
-                };
-
-                std::byte* space = trampolineStringLen->RawSpace(sizeof(spacePayload));
-                memcpy(space, spacePayload, sizeof(spacePayload));
-
-                WriteOffsetValue(space + 3 + 2 + 4 + 3 + 1, reinterpret_cast<intptr_t>(stringLenAddr) + 8);
-
-                const uint8_t funcPayload[] = {
-                    0x48, 0x8B, 0xDB, // mov rbx, rbx
-                    0xE9, 0x0, 0x0, 0x0, 0x0 // jmp space
-                };
-
-                memcpy(stringLenAddr, funcPayload, sizeof(funcPayload));
-
-                InjectHook(reinterpret_cast<intptr_t>(stringLenAddr) + 3, space, PATCH_JUMP);
-                cout << PATH_EXT_MSG;
-
-                // Hook the AddFileEntry method to get each filepath that is loaded in the game
-
-                // This function we're hooking is called from multiple places and the result we want to
-                // change will not be available after the function returns.
-                // So instead, hook the first couple of instructions of the function
-                renameFilePathsFunc = get_pattern("48 8D 8D 00 04 00 00 48 89 85 00 04 00 00", -0x62);
-                Trampoline* trampolineDE = Trampoline::MakeTrampoline(renameFilePathsFunc);
-
-                const uint8_t spacePayload2[] = {
-                    0xE9, 0x0, 0x0, 0x0, 0x0, // jmp Y6AddFileEntry
-                    0x48, 0x89, 0x4C, 0x24, 0x08, // mov qword ptr ss : [rsp + 8] , rcx
-                    0x55, // push rbp
-                    0x53, // push rbx
-                    0x41, 0x55, // push r13
-                    0xE9, 0x0, 0x0, 0x0, 0x0 // jmp renameFilePathsFunc+9
-                };
-
-                std::byte* space2 = trampolineDE->RawSpace(sizeof(spacePayload2));
-                memcpy(space2, spacePayload2, sizeof(spacePayload2));
-
-                intptr_t srcAddr = (intptr_t)(space2 + 5);
-                orgY6AddFileEntry = {};
-                memcpy(std::addressof(orgY6AddFileEntry), &srcAddr, sizeof(srcAddr));
-
-                InjectHook(space2, trampoline->Jump(Y6AddFileEntry));
-                WriteOffsetValue(space2 + 5 + 5 + 1 + 1 + 2 + 1, reinterpret_cast<intptr_t>(renameFilePathsFunc) + 9);
-
-                // First byte of the function is not writable for some reason, so instead we make the instruction do nothing
-                const uint8_t funcPayload2[] = {
-                    0x48, 0x89, 0xC9, // mov rcx, rcx
-                    0xE9, 0x0, 0x0, 0x0, 0x0, // jmp space2
-                    0x90 // nop
-                };
-
-                memcpy(renameFilePathsFunc, funcPayload2, sizeof(funcPayload2));
-
-                InjectHook(reinterpret_cast<intptr_t>(renameFilePathsFunc) + 3, space2, PATCH_JUMP);
-                cout << FILE_LOAD_MSG;
-
-                // AWB files are not passed over to the normal file entry function
-                auto sprintfAWBs = get_pattern("E8 ? ? ? ? 4C 8D 4C 24 60 45 33 C0 41 8B D7 49 8B CC");
-                ReadCall(sprintfAWBs, orgY6SprintfAwb);
-
-                InjectHook(sprintfAWBs, trampoline->Jump(Y6SprintfAwb));
-                cout << AWB_LOAD_MSG;
-                break;
-            }
-            case Game::YakuzaKiwami2:
-            {
-                // Hook inside the method that calculates a string's length to add 0x20 bytes to the length
-                // This is needed to prevent undefined behavior when the modified path is longer than the memory allocated to it
-                auto stringLenAddr = get_pattern("8B C7 3B D8 77 4E", -0x1C);
-
-                Trampoline* trampolineStringLen = Trampoline::MakeTrampoline(stringLenAddr);
-
-                const uint8_t spacePayload[] = {
-                    0x48, 0x8B, 0x09, // mov rcx, qword ptr ds:[rcx]
-                    0x48, 0x83, 0xC3, STR_LEN_ADD, // add rbx, 0x20
-                    0x48, 0x8B, 0xC1, // mov rax, rcx
-                    0x48, 0xC1, 0xE8, 0x2C, // shr rax, 0x2C
-                    0xE9, 0x0, 0x0, 0x0, 0x0 // jmp stringLenAddr+0xA
-                };
-
-                std::byte* space = trampolineStringLen->RawSpace(sizeof(spacePayload));
-                memcpy(space, spacePayload, sizeof(spacePayload));
-
-                WriteOffsetValue(space + 3 + 4 + 3 + 4 + 1, reinterpret_cast<intptr_t>(stringLenAddr) + 0xA);
-
-                const uint8_t funcPayload[] = {
-                    0x48, 0x8B, 0xDB, // mov rbx, rbx
-                    0x90, 0x90, // nop
-                    0xE9, 0x0, 0x0, 0x0, 0x0 // jmp space2
-                };
-
-                memcpy(stringLenAddr, funcPayload, sizeof(funcPayload));
-
-                InjectHook(reinterpret_cast<intptr_t>(stringLenAddr) + 5, space, PATCH_JUMP);
-                cout << PATH_EXT_MSG;
-
-                // Hook the AddFileEntry method to get each filepath that is loaded in the game
-
-                // Unlike Y6, K2 has a good place to hook the call instead of hooking the first instruction of the function
-                renameFilePathsFunc = get_pattern("4C 8D 44 24 20 48 8B D3 48 8B CF", -5);
-                ReadCall(renameFilePathsFunc, orgY6AddFileEntry);
-
-                InjectHook(renameFilePathsFunc, trampoline->Jump(Y6AddFileEntry));
-                cout << FILE_LOAD_MSG;
-
-                // AWB files are not passed over to the normal file entry function
-                auto sprintfAWBs = get_pattern("4C 8D 4C 24 70 45 33 C0 41 8B D5 49 8B CC", -5);
-                ReadCall(sprintfAWBs, orgY6SprintfAwb);
-
-                InjectHook(sprintfAWBs, trampoline->Jump(Y6SprintfAwb));
-                cout << AWB_LOAD_MSG;
-                break;
-            }
-            case Game::VFeSports:
-            {
-                renameFilePathsFunc = get_pattern("40 BA 10 04 00 00 E8", 6);
-                ReadCall(renameFilePathsFunc, orgVFeSAddFileEntry);
-
-                InjectHook(renameFilePathsFunc, trampoline->Jump(VFeSAddFileEntry));
-                cout << FILE_LOAD_MSG;
-
-                // Not really sure if this affects anything, but just in case
-                auto stringLenAddr = get_pattern("48 89 9C 24 A0 04 00 00 48 8B F9 B9 68 00 00 00 E8", 0xC);
-                Patch(stringLenAddr, 0x68 + STR_LEN_ADD);
-                cout << PATH_EXT_MSG;
-                break;
-            }
-            case Game::YakuzaLikeADragon:
-            {
-                // Y7 need hooks for two different functions
-
-                // File loading hook
-                if (isUwp)
-                {
-                    renameFilePathsFunc = get_pattern("48 83 EC 28 4C 8B C2 4C 8D 4C 24 40 BA 10 04 00 00 E8", 17);
-                }
-                else
-                {
-                    auto pat = pattern("48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 48 83 EC 28 4C 8B C2 4C 8D 4C 24 40 BA 10 04 00 00 E8");
-
-                    // Try the UWP pattern if the main pattern doesn't match
-                    if (pat.size() < 5)
-                    {
-                        renameFilePathsFunc = get_pattern("48 83 EC 28 4C 8B C2 4C 8D 4C 24 40 BA 10 04 00 00 E8", 17);
-                    }
-                    else
-                    {
-                        renameFilePathsFunc = pat.get(4).get<void>(32);
-                    }
-                }
-
-                ReadCall(renameFilePathsFunc, hookYLaDAddFileEntry);
-
-                if (MH_CreateHook(hookYLaDAddFileEntry, &YLaDAddFileEntry, reinterpret_cast<LPVOID*>(&orgYLaDAddFileEntry)) != MH_OK)
-                {
-                    cout << "Hook creation failed. Aborting.\n";
-                    return;
-                }
-
-                if (MH_EnableHook(hookYLaDAddFileEntry) != MH_OK)
-                {
-                    cout << "Hook could not be enabled. Aborting.\n";
-                    return;
-                }
-
-                // Filepath hook
-                if (isUwp)
-                {
-                    renameFilePathsFunc = get_pattern("44 8D 4F 03 BA 10 04 00 00 4C 8D 84 24 50 06 00 00 48 8D 8C 24 60 0A 00 00 E8", 25);
-                }
-                else
-                {
-                    renameFilePathsFunc = get_pattern("44 8D 4D 03 4C 8D 84 24 40 02 00 00 BA 10 04 00 00 48 8D 8C 24 B0 0C 00 00 E8", 25);
-                }
-
-                ReadCall(renameFilePathsFunc, hookYLaDFilepath);
-
-                if (MH_CreateHook(hookYLaDFilepath, &YLaDFilepath, reinterpret_cast<LPVOID*>(&orgYLaDFilepath)) != MH_OK)
-                {
-                    cout << "Hook creation failed. Aborting.\n";
-                    return;
-                }
-
-                if (MH_EnableHook(hookYLaDFilepath) != MH_OK)
-                {
-                    cout << "Hook could not be enabled. Aborting.\n";
-                    return;
-                }
-
-                cout << FILE_LOAD_MSG;
-                break;
-            }
-            case Game::Judgment:
-            case Game::LostJudgment:
-            {
-                hookLJAddFileEntry = (t_orgLJAddFileEntry*)pattern("41 57 48 8D A8 68 FE FF FF 48 81 EC 58 02 00 00 C5 F8 29 70 A8").get_first(-20);
-
-                if (MH_CreateHook(hookLJAddFileEntry, &LJAddFileEntry, reinterpret_cast<LPVOID*>(&orgLJAddFileEntry)) != MH_OK)
-                {
-                    cout << "Hook creation failed. Aborting.\n";
-                    return;
-                }
-
-                if (MH_EnableHook(hookLJAddFileEntry) != MH_OK)
-                {
-                    cout << "Hook could not be enabled. Aborting.\n";
-                    return;
-                }
-
-                // For some unknown reason, the pointer here is pointing to an interrupt (0xCC) that replaced the first byte of the trampoline space
-                *((char*)orgLJAddFileEntry) = 0x48;
-
-                cout << FILE_LOAD_MSG;
-
-                hook_BindCpk = (t_CriBind*)get_pattern("41 57 48 8B EC 48 83 EC 70 4C 8B 6D 58", -26);
-                org_BindDir = (t_CriBind)get_pattern("41 57 48 83 EC 30 48 8B 74 24 78 33 ED", -23);
-
-                if (MH_CreateHook(hook_BindCpk, &BindCpk, reinterpret_cast<LPVOID*>(&org_BindCpk)) != MH_OK)
-                {
-                    cout << "Hook creation failed. Aborting.\n";
-                    return;
-                }
-
-                if (MH_EnableHook(hook_BindCpk) != MH_OK)
-                {
-                    cout << "Hook could not be enabled. Aborting.\n";
-                    return;
-                }
-
-                // Same issue as above
-                *((char*)org_BindCpk) = 0x48;
-
-                cout << CPK_BIND_MSG;
-
-                break;
-            }
-            case Game::Unsupported:
-            default:
-                cout << currentGameName << " is unsupported. Aborting." << endl;
-                break;
-        }
-    }
-
-    modsLoaded = true;
-
-    cout << "Hook function finished.\n";
+	std::unique_ptr<ScopedUnprotect::Unprotect> Protect = ScopedUnprotect::UnprotectSectionOrFullModule(GetModuleHandle(nullptr), ".text");
+
+	using namespace Memory::VP;
+	using namespace hook;
+
+	using namespace Parless;
+
+	const char* FILE_LOAD_MSG = "Applied file loading hook.\n";
+	const char* CPK_LOAD_MSG = "Applied CPK loading hook.\n";
+	const char* CPK_BIND_MSG = "Applied CPK directory bind hook.\n";
+	const char* ADX_LOAD_MSG = "Applied ADX loading hook.\n";
+	const char* AWB_LOAD_MSG = "Applied AWB loading hook.\n";
+	const char* PATH_EXT_MSG = "Applied file path extension hook.\n";
+
+	// Read INI variables
+
+	// Obtain a path to the ASI
+	wchar_t wcModulePath[MAX_PATH];
+	GetModuleFileNameW(hDLLModule, wcModulePath, _countof(wcModulePath) - 3); // Minus max required space for extension
+	PathRenameExtensionW(wcModulePath, L".ini");
+
+	// Store the ASI's path for later
+	wstring asiPathW(wcModulePath);
+	asiPath = string(asiPathW.begin(), asiPathW.end());
+	replace(asiPath.begin(), asiPath.end(), '\\', '/');
+	asiPath = pathWithoutFilename(asiPath);
+
+	if (GetPrivateProfileIntW(L"Parless", L"TempDisabled", 0, wcModulePath))
+	{
+		WritePrivateProfileStringW(L"Parless", L"TempDisabled", L"0", wcModulePath);
+		return;
+	}
+
+	if (GetPrivateProfileIntW(L"Parless", L"ParlessEnabled", 1, wcModulePath) == 0)
+	{
+		return;
+	}
+
+	// LooseFilesEnabled is set to 0 by default in the INI
+	loadParless = GetPrivateProfileIntW(L"Overrides", L"LooseFilesEnabled ", 1, wcModulePath);
+	loadMods = GetPrivateProfileIntW(L"Overrides", L"ModsEnabled", 1, wcModulePath);
+	rebuildMLO = GetPrivateProfileIntW(L"Overrides", L"RebuildMLO", 0, wcModulePath);
+
+	int localeValue = GetPrivateProfileIntW(L"Overrides", L"Locale", 0, wcModulePath);
+
+	logMods = GetPrivateProfileIntW(L"Logs", L"LogMods", 0, wcModulePath);
+	logParless = GetPrivateProfileIntW(L"Logs", L"LogParless", 0, wcModulePath);
+	logAll = GetPrivateProfileIntW(L"Logs", L"LogAll", 0, wcModulePath);
+	ignoreNonPaths = GetPrivateProfileIntW(L"Logs", L"IgnoreNonPaths", 1, wcModulePath);
+
+	isUwp = GetPrivateProfileIntW(L"UWP", L"UWPGame", -1, wcModulePath) != -1;
+
+	if (GetPrivateProfileIntW(L"Debug", L"ConsoleEnabled", 0, wcModulePath))
+	{
+		// Open debugging console
+		AllocConsole();
+		FILE* fDummy;
+		freopen_s(&fDummy, "CONOUT$", "w", stdout);
+	}
+
+	// Get the name of the current game
+	wchar_t exePath[MAX_PATH + 1];
+	GetModuleFileNameW(NULL, exePath, MAX_PATH);
+
+	wstring wstr(exePath);
+	string currentGameName = basenameBackslashNoExt(string(wstr.begin(), wstr.end()));
+
+	cout << "Game Name: " << currentGameName << endl;
+
+	currentGame = getGame(currentGameName);
+	currentGameName = getGameName(currentGame);
+	currentLocale = localeValue < 4 && localeValue >= 0 ? Locale(localeValue) : Locale::English;
+
+	cout << "YakuzaParless v" << VERSION << "\n\n";
+	cout << "Detected game: " << currentGameName << (isUwp ? " UWP version" : "") << endl;
+
+	if (currentGame == Game::Unsupported)
+	{
+		cout << currentGameName << " is unsupported. Aborting." << endl;
+		return;
+	}
+
+	//BREAKS GAIDEN AND 8
+	Trampoline* trampoline = nullptr;
+
+	if (shouldCreateTrampoline())
+		trampoline = Trampoline::MakeTrampoline(GetModuleHandle(nullptr));
+
+	// Initialize the virtual->real map
+	gameMap = getGameMap(currentGame, currentLocale);
+
+	// Rebuild the MLO file
+	if (rebuildMLO)
+	{
+		if (currentGame == Game::Judgment || currentGame == Game::LostJudgment)
+		{
+			cout << "Not rebuilding MLO because it is unsupported by this game." << endl;
+		}
+		else
+		{
+			cout << "Rebuilding MLO... ";
+			RebuildMLO();
+			cout << "DONE!\n";
+		}
+	}
+
+	// Read MLO file
+	cout << "Reading MLO... ";
+	ReadModLoadOrder();
+	cout << "DONE!\n";
+
+	//Initialize Extensions/Script Mods
+	cout << "Initializing mod scripts... ";
+	InitializeScripts();
+	cout << "DONE!\n";
+
+	// These maps are filled after reading the MLO
+	if (!parlessPathMap.size())
+	{
+		cout << "No \".parless\" paths were found in the MLO.\n";
+		loadParless = false;
+	}
+	if (!fileModMap.size())
+	{
+		cout << "No mod files were found in the MLO.\n";
+		loadMods = false;
+	}
+
+	// Check if repacked pars exist (old engine only)
+	hasRepackedPars = filesystem::is_directory("mods/Parless");
+
+	if (!hasRepackedPars)
+	{
+		cout << "No repacked pars were found.\n";
+	}
+
+	cout << endl;
+
+	if (!(loadParless || loadMods || hasRepackedPars || logAll))
+	{
+		cout << "No mods were loaded. LogAll is disabled. No patches will be applied. Aborting.\n";
+	}
+	else
+	{
+		char pathToLog[MAX_PATH];
+
+		// Open log streams if logging is enabled, remove them otherwise
+		asiPath.copy(pathToLog, asiPath.length());
+		pathToLog[asiPath.length()] = '\0';
+		strcat_s(pathToLog, "/modOverrides.txt");
+		if (logMods) (*modOverrides).open(pathToLog, ios::out);
+		else remove(pathToLog);
+
+		asiPath.copy(pathToLog, asiPath.length());
+		pathToLog[asiPath.length()] = '\0';
+		strcat_s(pathToLog, "/parlessOverrides.txt");
+		if (logParless && loadParless) (*parlessOverrides).open(pathToLog, ios::out);
+		else remove(pathToLog);
+
+		asiPath.copy(pathToLog, asiPath.length());
+		pathToLog[asiPath.length()] = '\0';
+		strcat_s(pathToLog, "/allFilespaths.txt");
+		if (logAll) (*allFilepaths).open(pathToLog, ios::out);
+		else remove(pathToLog);
+
+		void* renameFilePathsFunc;
+
+		if (MH_Initialize() != MH_OK)
+		{
+			cout << "Minhook initialization failed. Aborting.\n";
+			return;
+		}
+
+		switch (currentGame)
+		{
+		case Game::Yakuza0:
+		case Game::YakuzaKiwami:
+			// might want to hook the other call of this function as well, but currently not necessary (?)
+			renameFilePathsFunc = get_pattern("48 89 44 24 20 48 8B D5 48 8B 0D ? ? ? ?", 15);
+			ReadCall(renameFilePathsFunc, orgY0AddFileEntry);
+
+			// this will take care of every file that is read from disk
+			InjectHook(renameFilePathsFunc, trampoline->Jump(Y0AddFileEntry));
+			cout << FILE_LOAD_MSG;
+
+			// Cpk
+			if (currentGame == Game::Yakuza0)
+			{
+				renameFilePathsFunc = get_pattern("8B 4D D7 4A 8D 74 28 20 48 83 E6 E0 48 8D BE 9F 02 00 00", -13);
+				ReadCall(renameFilePathsFunc, orgY0CpkEntry);
+
+				InjectHook(renameFilePathsFunc, trampoline->Jump(Y0CpkEntry));
+			}
+			else
+			{
+				// Yakuza Kiwami
+				renameFilePathsFunc = get_pattern("8B 4D DF 48 8D 70 20 49 03 F6 48 83 E6 E0", -13);
+				ReadCall(renameFilePathsFunc, orgY0CpkEntry);
+
+				InjectHook(renameFilePathsFunc, trampoline->Jump(Y0CpkEntry));
+			}
+
+			cout << CPK_LOAD_MSG;
+
+			break;
+		case Game::Yakuza3:
+		case Game::Yakuza4:
+		{
+			renameFilePathsFunc = get_pattern("66 89 83 44 02 00 00 E8 ? ? ? ? 48 8B C3 48 8B 8C 24 A0 03 00 00", -5);
+			ReadCall(renameFilePathsFunc, orgY3AddFileEntry);
+
+			InjectHook(renameFilePathsFunc, trampoline->Jump(Y3AddFileEntry));
+			cout << FILE_LOAD_MSG;
+
+			// Adx
+			renameFilePathsFunc = get_pattern("48 89 5C 24 18 57 48 81 EC 90 06 00 00 48 8B 05", 0x84);
+			ReadCall(renameFilePathsFunc, orgY3AdxEntry);
+
+			InjectHook(renameFilePathsFunc, trampoline->Jump(Y3AdxEntry));
+			cout << ADX_LOAD_MSG;
+			break;
+		}
+		case Game::Yakuza5:
+		{
+			renameFilePathsFunc = get_pattern("48 89 4C 24 20 49 8B D7 48 8B 0D ? ? ? ?", 15);
+			ReadCall(renameFilePathsFunc, orgY5AddFileEntry);
+
+			InjectHook(renameFilePathsFunc, trampoline->Jump(Y5AddFileEntry));
+			cout << FILE_LOAD_MSG;
+
+			hook_BindCpk = (t_CriBind*)get_pattern("41 57 48 8B EC 48 83 EC 70 4C 8B 6D 58 33 DB", -26);
+			org_BindDir = (t_CriBind)get_pattern("41 57 48 83 EC 30 48 8B 74 24 78 33 ED", -23);
+
+			if (MH_CreateHook(hook_BindCpk, &BindCpk, reinterpret_cast<LPVOID*>(&org_BindCpk)) != MH_OK)
+			{
+				cout << "Hook creation failed. Aborting.\n";
+				return;
+			}
+
+			if (MH_EnableHook(hook_BindCpk) != MH_OK)
+			{
+				cout << "Hook could not be enabled. Aborting.\n";
+				return;
+			}
+
+			org_BindCpk = (t_CriBind)((char*)org_BindCpk + 1);
+
+			cout << CPK_BIND_MSG;
+			break;
+		}
+		case Game::Yakuza6:
+		{
+			// Hook inside the method that calculates a string's length to add 0x20 bytes to the length
+			// This is needed to prevent undefined behavior when the modified path is longer than the memory allocated to it
+			auto stringLenAddr = get_pattern("8B CD 3B D9 77 47", -0x1C);
+
+			Trampoline* trampolineStringLen = Trampoline::MakeTrampoline(stringLenAddr);
+
+			const uint8_t spacePayload[] = {
+				0x48, 0x03, 0xD8, // add rbx, rax
+				0x2B, 0xDE, // sub ebx, esi
+				0x48, 0x83, 0xC3, STR_LEN_ADD, // add rbx, 0x20
+				0x48, 0x8B, 0x07, // mov rax, qword ptr ds:[rdi]
+				0xE9, 0x0, 0x0, 0x0, 0x0 // jmp stringLenAddr+8
+			};
+
+			std::byte* space = trampolineStringLen->RawSpace(sizeof(spacePayload));
+			memcpy(space, spacePayload, sizeof(spacePayload));
+
+			WriteOffsetValue(space + 3 + 2 + 4 + 3 + 1, reinterpret_cast<intptr_t>(stringLenAddr) + 8);
+
+			const uint8_t funcPayload[] = {
+				0x48, 0x8B, 0xDB, // mov rbx, rbx
+				0xE9, 0x0, 0x0, 0x0, 0x0 // jmp space
+			};
+
+			memcpy(stringLenAddr, funcPayload, sizeof(funcPayload));
+
+			InjectHook(reinterpret_cast<intptr_t>(stringLenAddr) + 3, space, PATCH_JUMP);
+			cout << PATH_EXT_MSG;
+
+			// Hook the AddFileEntry method to get each filepath that is loaded in the game
+
+			// This function we're hooking is called from multiple places and the result we want to
+			// change will not be available after the function returns.
+			// So instead, hook the first couple of instructions of the function
+			renameFilePathsFunc = get_pattern("48 8D 8D 00 04 00 00 48 89 85 00 04 00 00", -0x62);
+			Trampoline* trampolineDE = Trampoline::MakeTrampoline(renameFilePathsFunc);
+
+			const uint8_t spacePayload2[] = {
+				0xE9, 0x0, 0x0, 0x0, 0x0, // jmp Y6AddFileEntry
+				0x48, 0x89, 0x4C, 0x24, 0x08, // mov qword ptr ss : [rsp + 8] , rcx
+				0x55, // push rbp
+				0x53, // push rbx
+				0x41, 0x55, // push r13
+				0xE9, 0x0, 0x0, 0x0, 0x0 // jmp renameFilePathsFunc+9
+			};
+
+			std::byte* space2 = trampolineDE->RawSpace(sizeof(spacePayload2));
+			memcpy(space2, spacePayload2, sizeof(spacePayload2));
+
+			intptr_t srcAddr = (intptr_t)(space2 + 5);
+			orgY6AddFileEntry = {};
+			memcpy(std::addressof(orgY6AddFileEntry), &srcAddr, sizeof(srcAddr));
+
+			InjectHook(space2, trampoline->Jump(Y6AddFileEntry));
+			WriteOffsetValue(space2 + 5 + 5 + 1 + 1 + 2 + 1, reinterpret_cast<intptr_t>(renameFilePathsFunc) + 9);
+
+			// First byte of the function is not writable for some reason, so instead we make the instruction do nothing
+			const uint8_t funcPayload2[] = {
+				0x48, 0x89, 0xC9, // mov rcx, rcx
+				0xE9, 0x0, 0x0, 0x0, 0x0, // jmp space2
+				0x90 // nop
+			};
+
+			memcpy(renameFilePathsFunc, funcPayload2, sizeof(funcPayload2));
+
+			InjectHook(reinterpret_cast<intptr_t>(renameFilePathsFunc) + 3, space2, PATCH_JUMP);
+			cout << FILE_LOAD_MSG;
+
+			// AWB files are not passed over to the normal file entry function
+			auto sprintfAWBs = get_pattern("E8 ? ? ? ? 4C 8D 4C 24 60 45 33 C0 41 8B D7 49 8B CC");
+			ReadCall(sprintfAWBs, orgY6SprintfAwb);
+
+			InjectHook(sprintfAWBs, trampoline->Jump(Y6SprintfAwb));
+			cout << AWB_LOAD_MSG;
+			break;
+		}
+		case Game::YakuzaKiwami2:
+		{
+			// Hook inside the method that calculates a string's length to add 0x20 bytes to the length
+			// This is needed to prevent undefined behavior when the modified path is longer than the memory allocated to it
+			auto stringLenAddr = get_pattern("8B C7 3B D8 77 4E", -0x1C);
+
+			Trampoline* trampolineStringLen = Trampoline::MakeTrampoline(stringLenAddr);
+
+			const uint8_t spacePayload[] = {
+				0x48, 0x8B, 0x09, // mov rcx, qword ptr ds:[rcx]
+				0x48, 0x83, 0xC3, STR_LEN_ADD, // add rbx, 0x20
+				0x48, 0x8B, 0xC1, // mov rax, rcx
+				0x48, 0xC1, 0xE8, 0x2C, // shr rax, 0x2C
+				0xE9, 0x0, 0x0, 0x0, 0x0 // jmp stringLenAddr+0xA
+			};
+
+			std::byte* space = trampolineStringLen->RawSpace(sizeof(spacePayload));
+			memcpy(space, spacePayload, sizeof(spacePayload));
+
+			WriteOffsetValue(space + 3 + 4 + 3 + 4 + 1, reinterpret_cast<intptr_t>(stringLenAddr) + 0xA);
+
+			const uint8_t funcPayload[] = {
+				0x48, 0x8B, 0xDB, // mov rbx, rbx
+				0x90, 0x90, // nop
+				0xE9, 0x0, 0x0, 0x0, 0x0 // jmp space2
+			};
+
+			memcpy(stringLenAddr, funcPayload, sizeof(funcPayload));
+
+			InjectHook(reinterpret_cast<intptr_t>(stringLenAddr) + 5, space, PATCH_JUMP);
+			cout << PATH_EXT_MSG;
+
+			// Hook the AddFileEntry method to get each filepath that is loaded in the game
+
+			// Unlike Y6, K2 has a good place to hook the call instead of hooking the first instruction of the function
+			renameFilePathsFunc = get_pattern("4C 8D 44 24 20 48 8B D3 48 8B CF", -5);
+			ReadCall(renameFilePathsFunc, orgY6AddFileEntry);
+
+			InjectHook(renameFilePathsFunc, trampoline->Jump(Y6AddFileEntry));
+			cout << FILE_LOAD_MSG;
+
+			// AWB files are not passed over to the normal file entry function
+			auto sprintfAWBs = get_pattern("4C 8D 4C 24 70 45 33 C0 41 8B D5 49 8B CC", -5);
+			ReadCall(sprintfAWBs, orgY6SprintfAwb);
+
+			InjectHook(sprintfAWBs, trampoline->Jump(Y6SprintfAwb));
+			cout << AWB_LOAD_MSG;
+			break;
+		}
+		case Game::VFeSports:
+		{
+			renameFilePathsFunc = get_pattern("40 BA 10 04 00 00 E8", 6);
+			ReadCall(renameFilePathsFunc, orgVFeSAddFileEntry);
+
+			InjectHook(renameFilePathsFunc, trampoline->Jump(VFeSAddFileEntry));
+			cout << FILE_LOAD_MSG;
+
+			// Not really sure if this affects anything, but just in case
+			auto stringLenAddr = get_pattern("48 89 9C 24 A0 04 00 00 48 8B F9 B9 68 00 00 00 E8", 0xC);
+			Patch(stringLenAddr, 0x68 + STR_LEN_ADD);
+			cout << PATH_EXT_MSG;
+			break;
+		}
+		case Game::YakuzaLikeADragon:
+		{
+			// Y7 need hooks for two different functions
+
+			// File loading hook
+			if (isUwp)
+			{
+				renameFilePathsFunc = get_pattern("48 83 EC 28 4C 8B C2 4C 8D 4C 24 40 BA 10 04 00 00 E8", 17);
+			}
+			else
+			{
+				auto pat = pattern("48 89 54 24 10 4C 89 44 24 18 4C 89 4C 24 20 48 83 EC 28 4C 8B C2 4C 8D 4C 24 40 BA 10 04 00 00 E8");
+
+				// Try the UWP pattern if the main pattern doesn't match
+				if (pat.size() < 5)
+				{
+					renameFilePathsFunc = get_pattern("48 83 EC 28 4C 8B C2 4C 8D 4C 24 40 BA 10 04 00 00 E8", 17);
+				}
+				else
+				{
+					renameFilePathsFunc = pat.get(4).get<void>(32);
+				}
+			}
+
+			ReadCall(renameFilePathsFunc, hookYLaDAddFileEntry);
+
+			if (MH_CreateHook(hookYLaDAddFileEntry, &YLaDAddFileEntry, reinterpret_cast<LPVOID*>(&orgYLaDAddFileEntry)) != MH_OK)
+			{
+				cout << "Hook creation failed. Aborting.\n";
+				return;
+			}
+
+			if (MH_EnableHook(hookYLaDAddFileEntry) != MH_OK)
+			{
+				cout << "Hook could not be enabled. Aborting.\n";
+				return;
+			}
+
+			// Filepath hook
+			if (isUwp)
+			{
+				renameFilePathsFunc = get_pattern("44 8D 4F 03 BA 10 04 00 00 4C 8D 84 24 50 06 00 00 48 8D 8C 24 60 0A 00 00 E8", 25);
+			}
+			else
+			{
+				renameFilePathsFunc = get_pattern("44 8D 4D 03 4C 8D 84 24 40 02 00 00 BA 10 04 00 00 48 8D 8C 24 B0 0C 00 00 E8", 25);
+			}
+
+			ReadCall(renameFilePathsFunc, hookYLaDFilepath);
+
+			if (MH_CreateHook(hookYLaDFilepath, &YLaDFilepath, reinterpret_cast<LPVOID*>(&orgYLaDFilepath)) != MH_OK)
+			{
+				cout << "Hook creation failed. Aborting.\n";
+				return;
+			}
+
+			if (MH_EnableHook(hookYLaDFilepath) != MH_OK)
+			{
+				cout << "Hook could not be enabled. Aborting.\n";
+				return;
+			}
+
+			cout << FILE_LOAD_MSG;
+			break;
+		}
+		case Game::Judgment:
+		case Game::LostJudgment:
+		{
+			hookLJAddFileEntry = (t_orgLJAddFileEntry*)pattern("41 57 48 8D A8 68 FE FF FF 48 81 EC 58 02 00 00 C5 F8 29 70 A8").get_first(-20);
+
+			if (MH_CreateHook(hookLJAddFileEntry, &LJAddFileEntry, reinterpret_cast<LPVOID*>(&orgLJAddFileEntry)) != MH_OK)
+			{
+				cout << "Hook creation failed. Aborting.\n";
+				return;
+			}
+
+			if (MH_EnableHook(hookLJAddFileEntry) != MH_OK)
+			{
+				cout << "Hook could not be enabled. Aborting.\n";
+				return;
+			}
+
+			// For some unknown reason, the pointer here is pointing to an interrupt (0xCC) that replaced the first byte of the trampoline space
+			*((char*)orgLJAddFileEntry) = 0x48;
+
+			cout << FILE_LOAD_MSG;
+
+			hook_BindCpk = (t_CriBind*)get_pattern("41 57 48 8B EC 48 83 EC 70 4C 8B 6D 58", -26);
+			org_BindDir = (t_CriBind)get_pattern("41 57 48 83 EC 30 48 8B 74 24 78 33 ED", -23);
+
+			if (MH_CreateHook(hook_BindCpk, &BindCpk, reinterpret_cast<LPVOID*>(&org_BindCpk)) != MH_OK)
+			{
+				cout << "Hook creation failed. Aborting.\n";
+				return;
+			}
+
+			if (MH_EnableHook(hook_BindCpk) != MH_OK)
+			{
+				cout << "Hook could not be enabled. Aborting.\n";
+				return;
+			}
+
+			// Same issue as above
+			*((char*)org_BindCpk) = 0x48;
+
+			cout << CPK_BIND_MSG;
+
+			break;
+		}
+
+		case Game::LikeADragonGaidenTheManWhoErasedHisName:
+		{
+			hookGaidenAddFileEntry = (t_orgGaidenAddFileEntry*)pattern("48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 38 FE FF FF").get_first(0);
+
+			if (MH_CreateHook(hookGaidenAddFileEntry, &GaidenAddFileEntry, reinterpret_cast<LPVOID*>(&orgGaidenAddFileEntry)) != MH_OK)
+			{
+				cout << "Hook creation failed. Aborting.\n";
+				return;
+			}
+
+			if (MH_EnableHook(hookGaidenAddFileEntry) != MH_OK)
+			{
+				cout << "Hook could not be enabled. Aborting.\n";
+				return;
+			}
+
+			*((char*)orgGaidenAddFileEntry) = 0x48;
+
+			cout << FILE_LOAD_MSG;
+
+			break;
+		}
+		case Game::LikeADragonInfiniteWealth:
+		{
+			hookIWAddFileEntry = (t_orgIWAddFileEntry*)pattern("48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 38 FE FF FF").get_first(0);
+
+			if (MH_CreateHook(hookIWAddFileEntry, &IWAddFileEntry, reinterpret_cast<LPVOID*>(&orgIWAddFileEntry)) != MH_OK)
+			{
+				cout << "Hook creation failed. Aborting.\n";
+				return;
+			}
+
+			if (MH_EnableHook(hookIWAddFileEntry) != MH_OK)
+			{
+				cout << "Hook could not be enabled. Aborting.\n";
+				return;
+			}
+
+			*((char*)orgIWAddFileEntry) = 0x48;
+
+			cout << FILE_LOAD_MSG;
+
+			break;
+		}
+		case Game::Unsupported:
+		default:
+			cout << currentGameName << " is unsupported. Aborting." << endl;
+			break;
+		}
+	}
+
+	modsLoaded = true;
+
+	cout << "Hook function finished.\n";
 }
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
-    UNREFERENCED_PARAMETER(lpvReserved);
+	UNREFERENCED_PARAMETER(lpvReserved);
 
-    if (fdwReason == DLL_PROCESS_ATTACH)
-    {
-        hDLLModule = hinstDLL;
-    }
-    return TRUE;
+	if (fdwReason == DLL_PROCESS_ATTACH)
+	{
+		hDLLModule = hinstDLL;
+	}
+	return TRUE;
 }
 
 
 //Exports
 extern "C"
 {
-    __declspec(dllexport) const char* YP_GET_VERSION()
-    {
-        return Parless::VERSION;
-    }
+	__declspec(dllexport) const char* YP_GET_VERSION()
+	{
+		return Parless::VERSION;
+	}
 
-    __declspec(dllexport) bool YP_ARE_MODS_LOADED()
-    {
-        return Parless::modsLoaded;
-    }
+	__declspec(dllexport) bool YP_ARE_MODS_LOADED()
+	{
+		return Parless::modsLoaded;
+	}
 }

--- a/source/Parless.cpp
+++ b/source/Parless.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 namespace Parless
 {
-	const char* VERSION = "1.8.0";
+	const char* VERSION = "1.8.1";
 
 	typedef int (*t_CriBind)(void* param_1, void* param_2, const char* path, void* param_4, int param_5, void* bindId, int param_7);
 	t_CriBind(*hook_BindCpk);
@@ -99,6 +99,7 @@ namespace Parless
 
 	// Mod paths will be relative to the ASI's directory instead of the game's directory (to support undumped UWP games)
 	bool isUwp;
+	bool isXbox;
 
 	bool hasRepackedPars;
 
@@ -746,6 +747,12 @@ void OnInitializeHook()
 	wstring wstr(exePath);
 	string currentGameName = basenameBackslashNoExt(string(wstr.begin(), wstr.end()));
 
+	if (wstr.find(L"WindowsApps") != std::wstring::npos)
+	{
+		Parless::isXbox = true;
+		std::cout << "Game is GamePass/MS Store version" << std::endl;
+	}
+
 	cout << "Game Name: " << currentGameName << endl;
 
 	currentGame = getGame(currentGameName);
@@ -1183,7 +1190,10 @@ void OnInitializeHook()
 		case Game::LikeADragonGaidenTheManWhoErasedHisName:
 		{
 
-			hookGaidenAddFileEntry = (t_orgGaidenAddFileEntry*)pattern("48 8B C4 4C 89 48 20 89 50 10 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 68 FE FF FF").get_first(0);
+			if(!Parless::isXbox)
+				hookGaidenAddFileEntry = (t_orgGaidenAddFileEntry*)pattern("48 8B C4 4C 89 48 20 89 50 10 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 68 FE FF FF").get_first(0);
+			else
+				hookGaidenAddFileEntry = (t_orgGaidenAddFileEntry*)pattern("48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 38 FE FF FF").get_first(0);
 
 			if (MH_CreateHook(hookGaidenAddFileEntry, &GaidenAddFileEntry, reinterpret_cast<LPVOID*>(&orgGaidenAddFileEntry)) != MH_OK)
 			{
@@ -1205,7 +1215,10 @@ void OnInitializeHook()
 		}
 		case Game::LikeADragonInfiniteWealth:
 		{
-			hookIWAddFileEntry = (t_orgIWAddFileEntry*)pattern("48 8B C4 4C 89 48 20 89 50 10 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 68 FE FF FF").get_first(0);
+			if(!Parless::isXbox)
+				hookIWAddFileEntry = (t_orgIWAddFileEntry*)pattern("48 8B C4 4C 89 48 20 89 50 10 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 68 FE FF FF").get_first(0);
+			else
+				hookIWAddFileEntry = (t_orgIWAddFileEntry*)pattern("48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 38 FE FF FF").get_first(0);
 
 			if (MH_CreateHook(hookIWAddFileEntry, &IWAddFileEntry, reinterpret_cast<LPVOID*>(&orgIWAddFileEntry)) != MH_OK)
 			{

--- a/source/Parless.cpp
+++ b/source/Parless.cpp
@@ -30,7 +30,7 @@ using namespace std;
 
 namespace Parless
 {
-	const char* VERSION = "2.0.0";
+	const char* VERSION = "2.0.1";
 	
 	t_CriBind(*hook_BindCpk);
 	t_CriBind org_BindCpk = NULL;
@@ -144,36 +144,39 @@ namespace Parless
 
 			path = currentParlessGame->translate_path(path, indexOfData);
 
-			if (hasRepackedPars && endsWith(path, ".par"))
+			if (hasRepackedPars)
 			{
-				override = path;
-
-				// Redirect the path from data/ to mods/Parless/
-				override.erase(indexOfData, 4);
-				override.insert(indexOfData, "mods/Parless");
-
-				if (isUwp)
+				if (endsWith(path, ".par") || endsWith(path, ".cpk"))
 				{
-					override = asiPath + override.substr(indexOfData);
-					indexOfData = asiPath.length();
-				}
+					override = path;
 
-				if (filesystem::exists(override))
-				{
-					overridden = true;
+					// Redirect the path from data/ to mods/Parless/
+					override.erase(indexOfData, 4);
+					override.insert(indexOfData, "mods/Parless");
 
-					override.copy(filepath, override.length());
-					filepath[override.length()] = '\0';
-
-					if (logMods)
+					if (isUwp)
 					{
-						std::lock_guard<loggingStream> g_(modOverrides);
-						(*modOverrides) << filepath + indexOfData << std::endl;
+						override = asiPath + override.substr(indexOfData);
+						indexOfData = asiPath.length();
 					}
-				}
-				else
-				{
-					cout << "Par not found: " << override << std::endl;
+
+					if (filesystem::exists(override))
+					{
+						overridden = true;
+
+						override.copy(filepath, override.length());
+						filepath[override.length()] = '\0';
+
+						if (logMods)
+						{
+							std::lock_guard<loggingStream> g_(modOverrides);
+							(*modOverrides) << filepath + indexOfData << std::endl;
+						}
+					}
+					else
+					{
+						cout << "Par not found: " << override << std::endl;
+					}
 				}
 			}
 

--- a/source/ParlessGames.h
+++ b/source/ParlessGames.h
@@ -1,0 +1,80 @@
+#pragma once
+#include "Maps.h"
+#include "Games/CBaseParlessGame.h"
+#include "Games/ParlessGameOOE.h"
+#include "Games/ParlessGameY5.h"
+#include "Games/ParlessGameY0.h"
+#include "Games/ParlessGameYK1.h"
+#include "Games/ParlessGameY6.h"
+#include "Games/ParlessGameYK2.h"
+#include "Games/ParlessGameJudge.h"
+#include "Games/ParlessGameYLAD.h"
+#include "Games/ParlessGameLJ.h"
+#include "Games/ParlessGameTMWEHI.h"
+#include "Games/ParlessGameIW.h"
+
+CBaseParlessGame* get_parless_game(Game game)
+{
+	switch (game)
+	{
+	default:
+	{
+		return new CBaseParlessGame();
+	};
+
+	case Game::Yakuza3:
+	case Game::Yakuza4:
+	{
+		return new ParlessGameOOE();
+	};
+
+	case Game::Yakuza0:
+	{
+		return new ParlessGameY0();
+	}
+
+	case Game::YakuzaKiwami:
+	{
+		return new ParlessGameYK1();
+	}
+	case Game::Yakuza5:
+	{
+		return new ParlessGameY5();
+	};
+	case Game::Yakuza6:
+	{
+		return new ParlessGameY6();
+	};
+	case Game::YakuzaKiwami2:
+	{
+		return new ParlessGameYK2();
+	}
+
+	case Game::Judgment:
+	{
+		return new ParlessGameJudge();
+	};
+
+	case Game::YakuzaLikeADragon:
+	{
+		return new ParlessGameYLAD();
+	};
+	case Game::LostJudgment:
+	{
+		return new ParlessGameLJ();
+	};
+	case Game::LikeADragonGaidenTheManWhoErasedHisName:
+	{
+		return new ParlessGameTMWEHI();
+	};
+
+	case Game::LikeADragonInfiniteWealthDemo:
+	{
+		return new ParlessGameIW();
+	};
+	case Game::LikeADragonInfiniteWealth:
+	{
+		return new ParlessGameIW();
+	};
+	}
+}


### PR DESCRIPTION
This pull request introduces two new addittions.

1) Load ASI scripts in mod directories, based on order
2) Introduce two exported functions, YP_ARE_MODS_LOADED and YP_GET_VERSION.
YP_ARE_MODS_LOADED is crucial if ASI scripts want to wait YakuzaParless to be completely done loading before executing main code. YP_GET_VERSION returns the current version of YakuzaParless. 